### PR TITLE
Case study color scheme adaptation+ ordering of the boxes

### DIFF
--- a/bootstrap-custom/custom.scss
+++ b/bootstrap-custom/custom.scss
@@ -6,12 +6,11 @@
 $custom-colors: (
   "vhppink": #e6007e, //Colour for tools
   "vhppink_distinct": #c3007a, //Colour for regulatory question
-  "vhpblue": #307bbf, //Default color
+  "vhpblue": #307bbf, //Default color and tools/models/data
   "vhporange": #eb5b25, // Colour for flow steps
   "vhppurple": #29235c,
   "vhpteal": #0b5a6c, // Colour for workflow step
   "vhplight-blue": #c1e5f5,  // Colour for accents
-  "vhpdarkblue": #5079BB,    // Colour for tools/models/data
   "vhpdarkpurple": #593887, // Colour for process flow
   "vhplightteal": #6ba3b0 // Colour for workflow substep
 

--- a/static/css/bootstrap-custom.css
+++ b/static/css/bootstrap-custom.css
@@ -48,8 +48,8 @@
   --bs-vhplight-purple: #ac9cc4; /*== I added this one==*/
   --bs-vhplight-green: #ebf1df;
   --bs-vhppink_distinct: #c3007a;
+  --bs-vhpdarkteal: #005a6c;
   --bs-vhplightteal: #6ba3b0;
-  --bs-vhpdarkblue: #5079BB;
   --bs-vhpdarkpurple: #593887;
   --bs-primary-rgb: 13, 110, 253;
   --bs-secondary-rgb: 108, 117, 125;
@@ -60,6 +60,7 @@
   --bs-light-rgb: 248, 249, 250;
   --bs-dark-rgb: 33, 37, 41;
   --bs-vhppink-rgb: 230, 0, 126;
+  --bs-vhppink_distinct-rgb: 195, 0, 122;
   --bs-vhpblue-rgb: 48, 123, 191;
   --bs-vhporange-rgb: 235, 91, 37;
   --bs-vhppurple-rgb: 41, 35, 92;
@@ -3146,10 +3147,10 @@ textarea.form-control-lg {
 .btn-vhppink_distinct {
   --bs-btn-color: #fff;
   --bs-btn-bg: #c3007a;
-  --bs-btn-border-color: #e6007e;
+  --bs-btn-border-color: #c3007a;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: rgb(195.5, 0, 107.1);
-  --bs-btn-hover-border-color: rgb(184, 0, 100.8);
+  --bs-btn-hover-bg: #9b0363;
+  --bs-btn-hover-border-color: #9b0363;
   --bs-btn-focus-shadow-rgb: 234, 38, 145;
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: rgb(184, 0, 100.8);
@@ -3161,12 +3162,12 @@ textarea.form-control-lg {
 }
 
 .btn-vhpblue {
-  --bs-btn-color: #000;
+  --bs-btn-color: #ffffff;
   --bs-btn-bg: #307bbf;
   --bs-btn-border-color: #307bbf;
   --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: rgb(79.05, 142.8, 200.6);
-  --bs-btn-hover-border-color: rgb(68.7, 136.2, 197.4);
+  --bs-btn-hover-bg: #25629b;
+  --bs-btn-hover-border-color: #25629b;
   --bs-btn-focus-shadow-rgb: 41, 105, 162;
   --bs-btn-active-color: #000;
   --bs-btn-active-bg: rgb(89.4, 149.4, 203.8);
@@ -3175,24 +3176,6 @@ textarea.form-control-lg {
   --bs-btn-disabled-color: #000;
   --bs-btn-disabled-bg: #307bbf;
   --bs-btn-disabled-border-color: #307bbf;
-}
-
-
-.btn-vhpdarkblue {
-  --bs-btn-color: #000;
-  --bs-btn-bg: #5079bb;
-  --bs-btn-border-color: #5079bb;
-  --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: rgb(48,123,191);
-  --bs-btn-hover-border-color: rgb(80,121,187);
-  --bs-btn-focus-shadow-rgb: 48,123,191;
-  --bs-btn-active-color: #000;
-  --bs-btn-active-bg: rgb(80,121,187);
-  --bs-btn-active-border-color: rgb(80,121,187);
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #000;
-  --bs-btn-disabled-bg: #5079bb;
-  --bs-btn-disabled-border-color: #5079bb;
 }
 
 .btn-vhporange {
@@ -3231,19 +3214,19 @@ textarea.form-control-lg {
 
 .btn-vhpdarkpurple {
   --bs-btn-color: #fff;
-  --bs-btn-bg: #593887;
-  --bs-btn-border-color: #593887;
+  --bs-btn-bg: #64358c;
+  --bs-btn-border-color: #64358c;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: rgb(34.85, 29.75, 78.2);
-  --bs-btn-hover-border-color: rgb(32.8, 28, 73.6);
+  --bs-btn-hover-bg: #4c286c;
+  --bs-btn-hover-border-color: #4c286c;
   --bs-btn-focus-shadow-rgb: 73, 68, 116;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: rgb(32.8, 28, 73.6);
-  --bs-btn-active-border-color: rgb(30.75, 26.25, 69);
+  --bs-btn-active-bg: #64358c;
+  --bs-btn-active-border-color: #64358c;
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
-  --bs-btn-disabled-bg: #593887;
-  --bs-btn-disabled-border-color: #593887;
+  --bs-btn-disabled-bg: #64358c;
+  --bs-btn-disabled-border-color: #64358c;
 }
 
 .btn-vhpmaroon {
@@ -3281,17 +3264,35 @@ textarea.form-control-lg {
 }
 
 
-.btn-vhplightteal {
+.btn-vhpdarkteal {
   --bs-btn-color: #fff;
-  --bs-btn-bg: #6ba3b0;
-  --bs-btn-border-color: #6ba3b0;
+  --bs-btn-bg: #006a6c;
+  --bs-btn-border-color: #006a6c;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: rgb(82, 126, 136);
-  --bs-btn-hover-border-color: rgb(82, 126, 136);
+  --bs-btn-hover-bg: #025355;
+  --bs-btn-hover-border-color: #025355;
   --bs-btn-focus-shadow-rgb: 48, 115, 130;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: rgb(82, 126, 136);
-  --bs-btn-active-border-color: rgb(82, 126, 136);
+  --bs-btn-active-bg: #006a6c;
+  --bs-btn-active-border-color: #006a6c;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #fff;
+  --bs-btn-disabled-bg: #0b5a6c;
+  --bs-btn-disabled-border-color: #0b5a6c;
+}
+
+
+.btn-vhplightteal {
+  --bs-btn-color: #fff;
+  --bs-btn-bg: #45a6b2;
+  --bs-btn-border-color: #45a6b2;
+  --bs-btn-hover-color: #fff;
+  --bs-btn-hover-bg: #37848e;
+  --bs-btn-hover-border-color: #37848e;
+  --bs-btn-focus-shadow-rgb: 48, 115, 130;
+  --bs-btn-active-color: #fff;
+  --bs-btn-active-bg: #45a6b2;
+  --bs-btn-active-border-color: #45a6b2;
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #6ba3b0;
@@ -7338,6 +7339,11 @@ textarea.form-control-lg {
   background-color: RGBA(var(--bs-vhppink-rgb), var(--bs-bg-opacity, 1)) !important;
 }
 
+.text-bg-vhppink_distinct {
+  color: #fff !important;
+  background-color: RGBA(var(--bs-vhppink_distinct-rgb), var(--bs-bg-opacity, 1)) !important;
+}
+
 .text-bg-vhpblue {
   color: #000 !important;
   background-color: RGBA(var(--bs-vhpblue-rgb), var(--bs-bg-opacity, 1)) !important;
@@ -9513,6 +9519,11 @@ textarea.form-control-lg {
 .bg-vhppink {
   --bs-bg-opacity: 1;
   background-color: rgba(var(--bs-vhppink-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-vhppink_distinct {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-vhppink_distinct-rgb), var(--bs-bg-opacity)) !important;
 }
 
 .bg-vhpblue {
@@ -12757,6 +12768,13 @@ body {
 .card-button-vhppink:focus {
   color: var(--bs-vhppink);
   border-color: var(--bs-vhppink);
+}
+
+
+.card-button-vhppink_distinct:hover,
+.card-button-vhppink_distinct:focus {
+  color: var(--bs-vhppink_distinct);
+  border-color: var(--bs-vhppink_distinct);
 }
 
 .card-button-vhpblue:hover,

--- a/static/css/casestudies.css
+++ b/static/css/casestudies.css
@@ -117,9 +117,9 @@ nav.navbar {
 /* Coloring of the steps of the workflow diagram */
 .step-item[data-step="1"] .step-icon { background-color: var(--bs-vhppink_distinct); border-color: var(--bs-vhppink_distinct); }
 .step-item[data-step="2"] .step-icon { background-color: var(--bs-vhpdarkpurple);  border-color: var(--bs-vhpdarkpurple);}
-.step-item[data-step="3"] .step-icon { background-color: var(--bs-vhpteal); border-color: var(--bs-vhpteal); }
+.step-item[data-step="3"] .step-icon { background-color: var(--bs-vhpdarkteal); border-color: var(--bs-vhpdarkteal); }
 .step-item[data-step="4"] .step-icon { background-color: var(--bs-vhplightteal); border-color: var(--bs-vhplightteal); } /*== I added this bootstrap color, since the bs-version of the vhplight purple did not exist==*/
-.step-item[data-step="5"] .step-icon { background-color: var(--bs-vhpdarkblue) ; border-color: var(--bs-vhpdarkblue); }
+.step-item[data-step="5"] .step-icon { background-color: var(--bs-vhpblue) ; border-color: var(--bs-vhpblue); }
 
 /* === Case study sections === */
 .case-section {

--- a/static/js/casestudies.js
+++ b/static/js/casestudies.js
@@ -23,7 +23,7 @@ function stepTypeToColor(type) {
   baseclass = "btn text-white"
   color = "btn-vhpblue" 
   if (type == "workflow step" || type == "workflow-step") {
-    color = "btn-vhpteal"
+    color = "btn-vhpdarkteal"
   } else if (type == "workflow substep" || type == "workflow-substep") {
     color = "btn-vhplightteal"
   } else if (type == "process flow step" || type == "process-flow-step") {
@@ -31,7 +31,7 @@ function stepTypeToColor(type) {
   } else if (type == "regulatory question" || type == "regulatory-question") {
     color = "btn-vhppink_distinct"
   } else if (type == "tool") {
-    color = "btn-vhpdarkblue"
+    color = "btn-vhpblue"
   } else {
     console.log("UNKNOWN STEP TYPE: " + type)
   }

--- a/templates/base.html
+++ b/templates/base.html
@@ -113,8 +113,8 @@
 
      <!-- Case Studies Button Group -->
     <div class="btn-group" role="group">
-      <button class="btn btn-vhpblue text-white text-nowrap" style="min-width: 120px;" onclick="location.href='/casestudies'" type="button">Case Studies</button>
-      <button type="button" class="btn btn-vhpblue text-white dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+      <button class="btn btn-vhppink_distinct text-white text-nowrap" style="min-width: 120px;" onclick="location.href='/casestudies'" type="button">Case Studies</button>
+      <button type="button" class="btn btn-vhppink_distinct text-white dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
         <span class="visually-hidden">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu dropdown-scroll">
@@ -127,8 +127,8 @@
 
     <!-- Tools Button Group -->
     <div class="btn-group" role="group">
-      <button class="btn btn-vhppink text-nowrap" style="min-width: 120px;" onclick="location.href='/tools'" type="button">Tools</button>
-      <button type="button" class="btn btn-vhppink dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+      <button class="btn btn-vhpblue text-nowrap" style="min-width: 120px;" onclick="location.href='/tools'" type="button">Tools</button>
+      <button type="button" class="btn btn-vhpblue dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
         <span class="visually-hidden">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu dropdown-scroll">
@@ -215,8 +215,8 @@
 
       <!-- Case Studies collapse menu -->
       <div class="d-flex w-100 mt-2">
-        <button class="btn btn-vhpblue text-white flex-grow-1" onclick="location.href='/casestudies'" data-bs-dismiss="offcanvas">Case Studies</button>
-        <button class="btn btn-vhpblue text-white" type="button" data-bs-toggle="collapse" data-bs-target="#collapseCaseStudies" aria-expanded="false" aria-controls="collapseCaseStudies" style="width: 40px;">▼</button>
+        <button class="btn btn-vhppink_distinct text-white flex-grow-1" onclick="location.href='/casestudies'" data-bs-dismiss="offcanvas">Case Studies</button>
+        <button class="btn btn-vhppink_distinct text-white" type="button" data-bs-toggle="collapse" data-bs-target="#collapseCaseStudies" aria-expanded="false" aria-controls="collapseCaseStudies" style="width: 40px;">▼</button>
       </div>
       <div class="collapse" id="collapseCaseStudies">
         <div class="d-flex flex-column ps-3 gap-2">
@@ -228,8 +228,8 @@
 
       <!-- Tools collapse menu -->
       <div class="d-flex w-100 mt-2">
-        <button class="btn btn-vhppink flex-grow-1 text-nowrap" onclick="location.href='/tools'" data-bs-dismiss="offcanvas">Tools</button>
-        <button class="btn btn-vhppink" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTools" aria-expanded="false" aria-controls="collapseTools" style="width: 40px;">▼</button>
+        <button class="btn btn-vhpblue flex-grow-1 text-nowrap" onclick="location.href='/tools'" data-bs-dismiss="offcanvas">Tools</button>
+        <button class="btn btn-vhpblue" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTools" aria-expanded="false" aria-controls="collapseTools" style="width: 40px;">▼</button>
       </div>
       <div class="collapse" id="collapseTools">
         <div class="d-flex flex-column ps-3 gap-2">
@@ -282,7 +282,45 @@
         </div>
       </div>
 
-      <!-- Data Button -->
+      <!-- Methods button -->
+      <div class="d-flex w-100 mt-2">
+        <button
+          class="btn btn-vhplight-green flex-grow-1"
+          onclick="location.href='/methods'"
+          data-bs-dismiss="offcanvas">
+          Methods
+        </button>
+
+        <!-- Collapse toggle -->
+        <button
+          class="btn btn-vhplight-green"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#collapseMethods"
+          aria-expanded="false"
+          aria-controls="collapseMethods"
+          style="width: 40px;">
+          ▼
+        </button>
+      </div>
+
+      <!-- dropdownitems with Javier's logic-->
+      <div class="collapse" id="collapseMethods">
+        <div class="d-flex flex-column ps-3 gap-2 mt-1">
+          {% for m in methods_menu %}
+            <button
+              class="btn btn-light text-start"
+              onclick="location.href='/methods/{{ m.id }}'"
+              data-bs-dismiss="offcanvas">
+              {{ m.title }}
+            </button>
+          {% else %}
+            <span class="text-muted ps-2">No methods available</span>
+          {% endfor %}
+        </div>
+      </div>
+
+      <!-- Data button -->
       <button class="btn btn-vhpteal mt-2" onclick="location.href='/data'" data-bs-dismiss="offcanvas">Data</button>
     </div>
   </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -44,8 +44,8 @@
         <!-- Tools card -->
         <div class="col-md-4">
 
-          <div class="card text-center  card-button card-button-vhppink h-100 shadow-sm" onclick="location.href='/tools'">
-            <div class="card-header bg-vhppink ">
+          <div class="card text-center  card-button card-button-vhpblue h-100 shadow-sm" onclick="location.href='/tools'">
+            <div class="card-header bg-vhpblue ">
               <h5 class="card-title text-white m-0">Tools</h5>
             </div>
             <div class="card-body">
@@ -53,7 +53,7 @@
                 and get results relevant to your research.
             </div>
             <div class="card-footer text-body-secondary">
-              <span class="badge rounded-pill bg-vhppink text-white">{{num_tools}}</span> tools available
+              <span class="badge rounded-pill bg-vhpblue text-white">{{num_tools}}</span> tools available
             </div>
           </div>
         </div>
@@ -61,8 +61,8 @@
         <!-- Case Studies card -->
         <div class="col-md-4">
 
-          <div class="card text-center  card-button card-button-vhpblue h-100 shadow-sm" onclick="location.href='/casestudies'">
-            <div class="card-header bg-vhpblue ">
+          <div class="card text-center card-button card-button-vhppink_distinct h-100 shadow-sm" onclick="location.href='/casestudies'">
+            <div class="card-header bg-vhppink_distinct ">
               <h5 class="card-title text-white m-0">Case Studies</h5>
             </div>
             <div class="card-body">
@@ -70,7 +70,7 @@
               combined to best answer your research question.
             </div>
             <div class="card-footer text-body-secondary">
-              <span class="badge rounded-pill bg-vhpblue text-white">{{num_case_studies}}</span> case studies 
+              <span class="badge rounded-pill bg-vhppink_distinct text-white">{{num_case_studies}}</span> case studies 
             </div>
           </div>
         </div>


### PR DESCRIPTION
Changes made:

- Colorscheme of casestudy boxes in the individual casestudy pages and workflow bar has been changed to the one agreed in the meeting
- Color of actual casestudy button in website (header and homepage card-button) has been changed to the agreed color. As a consequence, tools has been colored blue for contrast and to match color used for tools in the case-study
- Order of the boxes in the header has been changed to the agreed one (case study first, then tools, methods and data) for desktop and mobile version
- Inclusion of Javier’s methods in the mobile offcanvas menu
- Inclusion of dropdown results in the mobile offcanvas menu

**Reference:**
https://solisservices.sharepoint.com/:p:/r/sites/VHP4SafetyProject/_layouts/15/Doc.aspx?sourcedoc=%7B83BD147B-F529-41BA-90F4-F916306C1D9F%7D&file=Casestudy%20color%20scheme.pptx&action=edit&mobileredirect=true

Video:

https://github.com/user-attachments/assets/dca02568-37d3-4564-8fa0-01bea8d55142


