### PR TITLE
PR for adding route for individual case study pages + methods card + inclusion model redirect in tool button

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,7 +134,7 @@ def home():
         "home.html",
         num_tools=num_tools,
         num_case_studies=num_case_studies,
-        num_datasets=num_datasets,
+        num_datasets=num_datasets
     )
 
 
@@ -714,9 +714,9 @@ def workflows():
 
 
 # Individual case study page, dynamically filled based on URL
-@app.route("/casestudies/<case>", defaults={"steps": ""})
-@app.route("/casestudies/<case>/<path:steps>")
-def casestudy(case, steps):
+@app.route("/casestudies/<case>", defaults={"step": ""})
+@app.route("/casestudies/<case>/<path:step>")
+def casestudy(case, step):
     if case not in CASESTUDIES:
         abort(404)
     #JS will handle steps via the URL

--- a/templates/base.html
+++ b/templates/base.html
@@ -174,6 +174,7 @@
         <li><a class="dropdown-item" href="/tools/kb">VHP4Safety Wikibase UI</a></li>
         <li><a class="dropdown-item" href="/tools/wikipathways_aop">WikiPathways-AOP Portal</a></li>
         <li><a class="dropdown-item" href="/tools/xploreaop">xploreaop</a></li>
+         <li><a class="dropdown-item" href="/models_page">VHP4Safety Models</a></li>
       </ul>
     </div>
 
@@ -276,6 +277,7 @@
           <button class="btn btn-light text-start" onclick="location.href='/tools/kb'" data-bs-dismiss="offcanvas">VHP4Safety Wikibase UI</button>
           <button class="btn btn-light text-start" onclick="location.href='/tools/wikipathways_aop'" data-bs-dismiss="offcanvas">WikiPathways-AOP Portal</button>
           <button class="btn btn-light text-start" onclick="location.href='/tools/xploreaop'" data-bs-dismiss="offcanvas">xploreaop</button>
+          <button class="btn btn-light text-start" onclick="location.href='/models_page'" data-bs-dismiss="offcanvas">VHP4Safety Models</button>
         </div>
       </div>
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -76,6 +76,23 @@
           </div>
         </div>
 
+        <!-- Methods card -->
+        <div class="col-md-4">
+
+          <div class="card text-center  card-button card-button-vhplight-green h-100 shadow-sm" onclick="location.href='/methods'">
+            <div class="card-header bg-vhplight-green ">
+              <h5 class="card-title text-black m-0">Methods</h5>
+            </div>
+            <div class="card-body">
+            Discover our VHP methods to streamline your workflows in risk assessment.
+            </div>
+            <div class="card-footer text-body-secondary">
+              <span class="badge rounded-pill bg-vhplight-green text-white">{{18}}</span> methods available
+            </div>
+          </div>
+        </div>
+
+
         <!-- Data card -->
         <div class="col-md-4">
 


### PR DESCRIPTION
* Current state: 404 error has been removed, methods container has been added and models.html is present under tools with the name: VHP4Safety models

* For the routing, it also appears that the state management of the js file is interfering when trying to adapt the js file to match the app.py file (step is added, matching to the URLs).   The result is that either  the whole navigation stops working, ithe URL takes the default settings (Q1/Kinetics/Oral) for each case study or it opens the URL without showing the json content (may to be too fast for the dynamic loading as you need to go one step back for the content to appear again), but then the default setting appears again when you navigate back to the start of the casestudy. 