### PR TITLE
Add param data-vhp-glossary-skip to set whether to highlight glossary words

### DIFF
--- a/static/js/glossary_highlighter.js
+++ b/static/js/glossary_highlighter.js
@@ -30,10 +30,9 @@
     
     // Exclusions and inclusions
     excludeTags: ['script', 'style', 'noscript', 'iframe', 'object'],
-    excludeAttributes: ['data-no-vhp-glossary', 'data-vhp-glossary-skip'],
     excludeClassSubstrings: ['vhp-highlight', 'highlighted'],
 
-    includeAttributes: ['data-vhp-glossary'],
+    excludeAttributes: ['data-vhp-glossary-skip'],
     
     // CSS Styling - Leave null to use base.css styles, or customize here to override
     // Set these values to override the default CSS styles in base.css
@@ -259,19 +258,19 @@
   function shouldProcessNode(node) {
     if (node.nodeType !== Node.TEXT_NODE || !node.textContent.trim()) return false;
 
-    // If includeAttributes is non-empty, only process nodes that are descendants
+    // If excludeAttributes is non-empty, only process nodes that are not descendants
     // of an element carrying one of those attributes.
-    if (CONFIG.includeAttributes.length) {
+    if (CONFIG.excludeAttributes.length) {
       let el = node.parentElement;
-      let insideIncluded = false;
+      let insideExcluded = false;
       while (el) {
-        if (CONFIG.includeAttributes.some(attr => el.hasAttribute(attr))) {
-          insideIncluded = true;
+        if (CONFIG.excludeAttributes.some(attr => el.hasAttribute(attr))) {
+          insideExcluded = true;
           break;
         }
         el = el.parentElement;
       }
-      if (!insideIncluded) return false;
+      if (insideExcluded) return false;
     }
 
     let parent = node.parentElement;

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -4,7 +4,7 @@
 
 <section class="container py-md-5 py-3 d-flex flex-column min-vh-100">
     <!-- Page Title and Description -->
-    <div class="">
+    <div data-vhp-glossary-skip class="">
         <h1><span class="text-vhpteal" id="collection-name">{{ collection_name or 'Data catalog' }} Data</span></h1>
         <p class="text-secondary fs-5">Explore datasets generated or used in <span id="collection-name-sub">{{ collection_name }} and hosted on BioStudies archive.</span></p>
     </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -125,7 +125,7 @@
         </button>
       </h2>
       <div id="about-collapseOne" class="accordion-collapse collapse show" aria-labelledby="about-headingOne">
-        <div class="accordion-body" data-vhp-glossary style="text-align: justify;">
+        <div class="accordion-body" style="text-align: justify;">
           <p>
             The Virtual Human Platform (VHP) was developed through the VHP4Safety project to support chemical and pharmaceutical safety testing.  VHP aims to facilitate the prediction of harmful effects of chemicals and pharmaceuticals by integrating human physiology, chemical properties, and biological pathway disturbances. VHP provides you with human-relevant tools and models for precision safety evaluation, helping you reduce reliance on laboratory animals. With VHP, you can assess chemicals for human use, including vulnerable populations such as infants, the elderly, and individuals with health conditions.
           </p>


### PR DESCRIPTION
The `data-vhp-glossary-skip` attribute can be added now to any element for it to skip glossary words highlighting. 
```
<div class="some-class" data-vhp-glossary-skip>
```
Will not highlight words in that div. 