### PR TITLE
feat(funding): Funding in Footer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -310,7 +310,7 @@
         </div>
         <div class="row mt-3">
           <div class="col-12 text-center">
-            <p class="mb-0 small">&copy; 2025 VHP4Safety, Licensed with <a href="https://github.com/VHP4Safety/virtual-human-platform/blob/main/LICENSE.md">AGPL-3</a></p>
+            <p class="mb-0 small">&copy; 2026 VHP4Safety, Licensed with <a href="https://github.com/VHP4Safety/virtual-human-platform/blob/main/LICENSE.md">AGPL-3</a>, Funded by <a href="https://www.nwo.nl">NWO</a> under file number <a href="https://www.nwo.nl/en/projects/nwa129219272">NWA.1292.19.272</a></p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<img width="1187" height="256" alt="image" src="https://github.com/user-attachments/assets/d94d4f80-8fb0-4943-a008-7648b3400122" />


kept it simple. No logo for now. NWO logo is still in `partners` section. 

fixes https://github.com/VHP4Safety/wp1.1/issues/125