### PR TITLE
fix(color): bring back vhpdarkteal

### DIFF
--- a/bootstrap-custom/custom.scss
+++ b/bootstrap-custom/custom.scss
@@ -13,7 +13,7 @@ $custom-colors: (
   "vhplight-blue": #c1e5f5,  // Colour for accents
   "vhpdarkpurple": #593887, // Colour for process flow
   "vhplightteal": #6ba3b0, // Colour for workflow substep
-  "vhpdarkteal": #0b3a4c, // Colour for dark teal
+  "vhpdarkteal": #006a6c, // Colour for dark teal
   "vhpmaroon": #8f2d57,
   "vhplight-purple": #ac9cc4,
   "vhplight-green": #ebf1df,

--- a/static/css/bootstrap-custom.css
+++ b/static/css/bootstrap-custom.css
@@ -47,7 +47,7 @@
   --bs-vhplight-blue: #c1e5f5;
   --bs-vhpdarkpurple: #593887;
   --bs-vhplightteal: #6ba3b0;
-  --bs-vhpdarkteal: #0b3a4c;
+  --bs-vhpdarkteal: #006a6c;
   --bs-vhpmaroon: #8f2d57;
   --bs-vhplight-purple: #ac9cc4;
   --bs-vhplight-green: #ebf1df;
@@ -68,7 +68,7 @@
   --bs-vhplight-blue-rgb: 193, 229, 245;
   --bs-vhpdarkpurple-rgb: 89, 56, 135;
   --bs-vhplightteal-rgb: 107, 163, 176;
-  --bs-vhpdarkteal-rgb: 11, 58, 76;
+  --bs-vhpdarkteal-rgb: 0, 106, 108;
   --bs-vhpmaroon-rgb: 143, 45, 87;
   --bs-vhplight-purple-rgb: 172, 156, 196;
   --bs-vhplight-green-rgb: 235, 241, 223;
@@ -89,7 +89,7 @@
   --bs-vhplight-blue-text-emphasis: rgb(77.2, 91.6, 98);
   --bs-vhpdarkpurple-text-emphasis: rgb(35.6, 22.4, 54);
   --bs-vhplightteal-text-emphasis: rgb(42.8, 65.2, 70.4);
-  --bs-vhpdarkteal-text-emphasis: rgb(4.4, 23.2, 30.4);
+  --bs-vhpdarkteal-text-emphasis: rgb(0, 42.4, 43.2);
   --bs-vhpmaroon-text-emphasis: rgb(57.2, 18, 34.8);
   --bs-vhplight-purple-text-emphasis: rgb(68.8, 62.4, 78.4);
   --bs-vhplight-green-text-emphasis: rgb(94, 96.4, 89.2);
@@ -110,7 +110,7 @@
   --bs-vhplight-blue-bg-subtle: rgb(242.6, 249.8, 253);
   --bs-vhpdarkpurple-bg-subtle: rgb(221.8, 215.2, 231);
   --bs-vhplightteal-bg-subtle: rgb(225.4, 236.6, 239.2);
-  --bs-vhpdarkteal-bg-subtle: rgb(206.2, 215.6, 219.2);
+  --bs-vhpdarkteal-bg-subtle: rgb(204, 225.2, 225.6);
   --bs-vhpmaroon-bg-subtle: rgb(232.6, 213, 221.4);
   --bs-vhplight-purple-bg-subtle: rgb(238.4, 235.2, 243.2);
   --bs-vhplight-green-bg-subtle: rgb(251, 252.2, 248.6);
@@ -131,7 +131,7 @@
   --bs-vhplight-blue-border-subtle: rgb(230.2, 244.6, 251);
   --bs-vhpdarkpurple-border-subtle: rgb(188.6, 175.4, 207);
   --bs-vhplightteal-border-subtle: rgb(195.8, 218.2, 223.4);
-  --bs-vhpdarkteal-border-subtle: rgb(157.4, 176.2, 183.4);
+  --bs-vhpdarkteal-border-subtle: rgb(153, 195.4, 196.2);
   --bs-vhpmaroon-border-subtle: rgb(210.2, 171, 187.8);
   --bs-vhplight-purple-border-subtle: rgb(221.8, 215.4, 231.4);
   --bs-vhplight-green-border-subtle: rgb(247, 249.4, 242.2);
@@ -224,7 +224,7 @@
   --bs-vhplight-blue-text-emphasis: rgb(217.8, 239.4, 249);
   --bs-vhpdarkpurple-text-emphasis: rgb(155.4, 135.6, 183);
   --bs-vhplightteal-text-emphasis: rgb(166.2, 199.8, 207.6);
-  --bs-vhpdarkteal-text-emphasis: rgb(108.6, 136.8, 147.6);
+  --bs-vhpdarkteal-text-emphasis: rgb(102, 165.6, 166.8);
   --bs-vhpmaroon-text-emphasis: rgb(187.8, 129, 154.2);
   --bs-vhplight-purple-text-emphasis: rgb(205.2, 195.6, 219.6);
   --bs-vhplight-green-text-emphasis: rgb(243, 246.6, 235.8);
@@ -245,7 +245,7 @@
   --bs-vhplight-blue-bg-subtle: rgb(38.6, 45.8, 49);
   --bs-vhpdarkpurple-bg-subtle: rgb(17.8, 11.2, 27);
   --bs-vhplightteal-bg-subtle: rgb(21.4, 32.6, 35.2);
-  --bs-vhpdarkteal-bg-subtle: rgb(2.2, 11.6, 15.2);
+  --bs-vhpdarkteal-bg-subtle: rgb(0, 21.2, 21.6);
   --bs-vhpmaroon-bg-subtle: rgb(28.6, 9, 17.4);
   --bs-vhplight-purple-bg-subtle: rgb(34.4, 31.2, 39.2);
   --bs-vhplight-green-bg-subtle: rgb(47, 48.2, 44.6);
@@ -266,7 +266,7 @@
   --bs-vhplight-blue-border-subtle: rgb(115.8, 137.4, 147);
   --bs-vhpdarkpurple-border-subtle: rgb(53.4, 33.6, 81);
   --bs-vhplightteal-border-subtle: rgb(64.2, 97.8, 105.6);
-  --bs-vhpdarkteal-border-subtle: rgb(6.6, 34.8, 45.6);
+  --bs-vhpdarkteal-border-subtle: rgb(0, 63.6, 64.8);
   --bs-vhpmaroon-border-subtle: rgb(85.8, 27, 52.2);
   --bs-vhplight-purple-border-subtle: rgb(103.2, 93.6, 117.6);
   --bs-vhplight-green-border-subtle: rgb(141, 144.6, 133.8);
@@ -3363,19 +3363,19 @@ textarea.form-control-lg {
 
 .btn-vhpdarkteal {
   --bs-btn-color: #fff;
-  --bs-btn-bg: #0b3a4c;
-  --bs-btn-border-color: #0b3a4c;
+  --bs-btn-bg: #006a6c;
+  --bs-btn-border-color: #006a6c;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: rgb(9.35, 49.3, 64.6);
-  --bs-btn-hover-border-color: rgb(8.8, 46.4, 60.8);
-  --bs-btn-focus-shadow-rgb: 48, 88, 103;
+  --bs-btn-hover-bg: rgb(0, 90.1, 91.8);
+  --bs-btn-hover-border-color: rgb(0, 84.8, 86.4);
+  --bs-btn-focus-shadow-rgb: 38, 128, 130;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: rgb(8.8, 46.4, 60.8);
-  --bs-btn-active-border-color: rgb(8.25, 43.5, 57);
+  --bs-btn-active-bg: rgb(0, 84.8, 86.4);
+  --bs-btn-active-border-color: rgb(0, 79.5, 81);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
-  --bs-btn-disabled-bg: #0b3a4c;
-  --bs-btn-disabled-border-color: #0b3a4c;
+  --bs-btn-disabled-bg: #006a6c;
+  --bs-btn-disabled-border-color: #006a6c;
 }
 
 .btn-vhpmaroon {
@@ -3719,19 +3719,19 @@ textarea.form-control-lg {
 }
 
 .btn-outline-vhpdarkteal {
-  --bs-btn-color: #0b3a4c;
-  --bs-btn-border-color: #0b3a4c;
+  --bs-btn-color: #006a6c;
+  --bs-btn-border-color: #006a6c;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #0b3a4c;
-  --bs-btn-hover-border-color: #0b3a4c;
-  --bs-btn-focus-shadow-rgb: 11, 58, 76;
+  --bs-btn-hover-bg: #006a6c;
+  --bs-btn-hover-border-color: #006a6c;
+  --bs-btn-focus-shadow-rgb: 0, 106, 108;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #0b3a4c;
-  --bs-btn-active-border-color: #0b3a4c;
+  --bs-btn-active-bg: #006a6c;
+  --bs-btn-active-border-color: #006a6c;
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #0b3a4c;
+  --bs-btn-disabled-color: #006a6c;
   --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #0b3a4c;
+  --bs-btn-disabled-border-color: #006a6c;
   --bs-gradient: none;
 }
 
@@ -7821,8 +7821,8 @@ textarea.form-control-lg {
   text-decoration-color: RGBA(var(--bs-vhpdarkteal-rgb), var(--bs-link-underline-opacity, 1)) !important;
 }
 .link-vhpdarkteal:hover, .link-vhpdarkteal:focus {
-  color: RGBA(9, 46, 61, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(9, 46, 61, var(--bs-link-underline-opacity, 1)) !important;
+  color: RGBA(0, 85, 86, var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(0, 85, 86, var(--bs-link-underline-opacity, 1)) !important;
 }
 
 .link-vhpmaroon {


### PR DESCRIPTION
Also now including vhpdarkteal

<img width="1274" height="587" alt="Screenshot 2026-03-17 at 00 08 15" src="https://github.com/user-attachments/assets/c8c3f5cb-448e-4054-b0d9-1c1583259c67" />

But still doesn't solve everything.


<img width="1267" height="580" alt="Screenshot 2026-03-17 at 00 08 24" src="https://github.com/user-attachments/assets/0add3dce-f3b1-4aa9-92c0-2a8e64a8b206" />
