### PR TITLE
Added a basic sitemap

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import re
 
 import requests
 import urllib.parse
-from flask import Flask, abort, jsonify, render_template, request
+from flask import Flask, abort, jsonify, render_template, request, Response
 from flask_caching import Cache
 from jinja2 import TemplateNotFound
 from werkzeug.routing import BaseConverter
@@ -286,6 +286,32 @@ def home():
         num_case_studies=num_case_studies,
         num_datasets=num_datasets,
     )
+
+
+################################################################################
+### The sitemap.xml for search engines
+@app.route("/sitemap.xml")
+def sitemap():
+    sitemapContent = """<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://platform.vhp4safety.nl/</loc>
+  </url>
+  <url>
+    <loc>https://platform.vhp4safety.nl/casestudies</loc>
+  </url>
+  <url>
+    <loc>https://platform.vhp4safety.nl/tools</loc>
+  </url>
+  <url>
+    <loc>https://platform.vhp4safety.nl/methods</loc>
+  </url>
+  <url>
+    <loc>https://platform.vhp4safety.nl/data</loc>
+  </url>
+</urlset>
+""";
+    return Response(sitemapContent, mimetype='text/xml');
 
 
 ################################################################################


### PR DESCRIPTION
Make a start with implementing https://github.com/VHP4Safety/wp1.1/issues/131

It hardcodes a few core pages, but I like the `sitemap.xml` in the future to also list URLs of datasets, methods, tools, and case studies.