### PR TITLE
Fix dropdown arrow color and process steps spacing

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -152,8 +152,8 @@
     <!-- Tools Button Group -->
  
     <div class="btn-group"  role="group">
-      <button class="btn btn-vhpblue text-nowrap" style="width:120px" onclick="location.href='/tools'" type="button">Tools</button>
-      <button class="btn btn-vhpblue dropdown-toggle-split dropdown-toggle" style="width:30px" type="button" id="toolsMenuBtn" data-bs-toggle="dropdown" aria-expanded="false">
+      <button class="btn btn-vhpblue text-nowrap text-white" style="width:120px" onclick="location.href='/tools'" type="button">Tools</button>
+      <button class="btn btn-vhpblue dropdown-toggle-split dropdown-toggle text-white" style="width:30px" type="button" id="toolsMenuBtn" data-bs-toggle="dropdown" aria-expanded="false">
         <span class="visually-hidden">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu dropdown-menu-end" id="toolsMenu" aria-labelledby="toolsMenuBtn" data-page-size="12">
@@ -238,8 +238,8 @@
 
       <!-- Tools collapse menu -->
       <div class="btn-group">
-        <button class="btn btn-vhpblue " onclick="location.href='/tools'" data-bs-dismiss="offcanvas">Tools</button>
-        <button class="btn btn-vhpblue dropdown-toggle dropdown-toggle-split" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTools" aria-expanded="false" aria-controls="collapseTools" style="max-width: 30vw;"></button>
+        <button class="btn btn-vhpblue text-white" onclick="location.href='/tools'" data-bs-dismiss="offcanvas">Tools</button>
+        <button class="btn btn-vhpblue dropdown-toggle dropdown-toggle-split text-white" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTools" aria-expanded="false" aria-controls="collapseTools" style="max-width: 30vw;"></button>
       </div>
       <div class="collapse" id="collapseTools">
         <div class="d-flex flex-column ps-3 gap-2">

--- a/templates/home.html
+++ b/templates/home.html
@@ -43,27 +43,42 @@
     <div class="col-12 mb-3">
       <h3 class="text-vhpblue">Safety Assessment Workflow </h3>
       <p class="text-muted">
-        The Virtual Human Platform implements a generic safety assessment as a five-step process.
+        The Virtual Human Platform implements a generic safety assessment as a six-step process.
       </p>
     </div>
 
     <div class="col-12">
-      <div class="row row-cols-1 row-cols-md-6 gap-3 mx-auto mt-1">
-          <div class="btn btn-primary btn-vhpblue card-button-vhpblue">
-          Exposure
+      <div class="row row-cols-1 row-cols-md-6 g-3">
+        <div class="col d-grid">
+          <div class="btn btn-vhpblue text-white d-flex align-items-center justify-content-center text-center">
+            Hazard & Chemical Characterization
           </div>
-          <div class="btn btn-primary btn-vhpblue card-button-vhpblue">
-          Toxicokinetics
+        </div>
+        <div class="col d-grid">
+          <div class="btn btn-vhpblue text-white d-flex align-items-center justify-content-center text-center">
+            External Exposure
           </div>
-          <div class="btn btn-primary btn-vhpblue card-button-vhpblue">
-          Toxicodynamics
+        </div>
+        <div class="col d-grid">
+          <div class="btn btn-vhpblue text-white d-flex align-items-center justify-content-center text-center">
+            Toxicokinetics
           </div>
-          <div class="btn btn-primary btn-vhpblue card-button-vhpblue">
-          Adverse Outcome
+        </div>
+        <div class="col d-grid">
+          <div class="btn btn-vhpblue text-white d-flex align-items-center justify-content-center text-center">
+            Internal Exposure
           </div>
-          <div class="btn btn-primary btn-vhpblue card-button-vhpblue">
-          Chemical Characteristics and Hazard Identification
+        </div>
+        <div class="col d-grid">
+          <div class="btn btn-vhpblue text-white d-flex align-items-center justify-content-center text-center">
+            AOP
           </div>
+        </div>
+        <div class="col d-grid">
+          <div class="btn btn-vhpblue text-white d-flex align-items-center justify-content-center text-center">
+            Adverse Outcome
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<img width="1460" height="669" alt="Screenshot 2026-05-13 at 02 27 52" src="https://github.com/user-attachments/assets/7953cbee-aad3-485c-b6af-46fdc53900e9" />

- Added `text-white` to the Tools split button (desktop nav + mobile offcanvas) so the label is readable on the `btn-vhpblue`
  background.
- Rebuild the Safety Assessment Workflow grid on the home page. Buttons now have equal width and height across the row, with text centered both axes. Still not convinced we need this on the main page, but looks a bit neater.
- Updated the step labels to six-step process (Hazard & Chemical Characterization, External Exposure, Toxicokinetics,Internal Exposure, AOP, Adverse Outcome) and adjust the copy ("five-step" → "six-step"). Although not clear to me what the final workflow step titles are.