### PR TITLE
Jh fix towardsvhp button

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -281,8 +281,8 @@
       </div>
       <!-- Implementation links (mobile) -->
 	    <div class="btn-group">
-        <button class="btn bg-secondary text-light" data-bs-dismiss="offcanvas">Towards a virtual human</button>
-        <button class="btn bg-secondary text-light dropdown-toggle dropdown-toggle-split" type="button" data-bs-toggle="collapse" data-bs-target="#collapseImplementation" aria-expanded="false" aria-controls="collapseImplementation" style="max-width: 30vw;"></button>
+        <button class="btn btn-outline-secondary" data-bs-dismiss="offcanvas">Towards a virtual human </button>
+        <button class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split flex-grow-0" type="button" data-bs-toggle="collapse" data-bs-target="#collapseImplementation" aria-expanded="false" aria-controls="collapseImplementation" style="width: 3rem;"></button>
       </div>
       <div class="collapse" id="collapseImplementation">
         <div class="d-flex flex-column ps-3 gap-2">

--- a/templates/base.html
+++ b/templates/base.html
@@ -80,19 +80,6 @@
 
   <!-- Desktop buttons (hidden on mobile) -->
   <div class="d-none d-lg-flex align-items-center gap-3">
-
-  <!-- Collapsible implementation menu -->
-	 <div class="btn-group" role="group" >
-      <button class="toggler bg-white border-secondary rounded" type="button" style="min-width:30px"  data-bs-toggle="dropdown" aria-expanded="false">
-		<span class="navbar-toggler-icon"></span>
-		<span class="visually-hidden">Toggle Dropdown</span>
-      </button>
-      <ul class="dropdown-menu dropdown-menu-end">
-        <li><a class="dropdown-item" href="/explore_our_work">Explore our work</a></li>
-        <li><a class="dropdown-item" href="/training">Training</a></li>
-        <li><a class="dropdown-item" href="/impact">Impact</a></li>
-      </ul>
-    </div>
     
     <!-- Glossary Toggle Switch -->
     <div class="form-check form-switch mb-0 text-nowrap" data-vhp-glossary-skip>
@@ -135,6 +122,19 @@
       </form>
     </div>
 
+    <!-- Collapsible implementation menu -->
+	 <div class="btn-group" role="group" >
+      <button class="btn btn-outline-secondary text-nowrap" style="width:120px" onclick="location.href='{{ url_for('home') }}#about-section'" type="button">About</button>
+      <button type="button" style="min-width:30px" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+		<span class="visually-hidden">Toggle Dropdown</span>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-end">
+        <li><a class="dropdown-item" href="/explore_our_work">Process</a></li>
+        <li><a class="dropdown-item" href="/training">Training</a></li>
+        <li><a class="dropdown-item" href="/impact">Impact</a></li>
+      </ul>
+    </div>
+
      <!-- Case Studies Button Group -->
     <div class="btn-group" role="group">
       <button class="btn btn-vhppink-distinct text-white text-nowrap" style="width:120px" onclick="location.href='/casestudies'" type="button">Case Studies</button>
@@ -175,6 +175,7 @@
 
     <!-- Data Button -->
     <button class="btn btn-vhpteal text-nowrap" style="width: 150px;" onclick="location.href='/data'" type="button">Data</button>
+
   </div>
 </nav>
 
@@ -185,7 +186,7 @@
     <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
   </div>
   <div class="offcanvas-body">
-    <div class="d-flex flex-column gap-2">
+    <div class="d-flex flex-column gap-2 h-100">
 
       <!-- Search -->
       <div class="" >
@@ -279,16 +280,18 @@
                          this.closest('.offcanvas') && bootstrap.Offcanvas.getInstance(this.closest('.offcanvas'))?.hide();">
         <label class="form-check-label" for="glossary-toggle-mobile">Glossary</label>
       </div>
-      <!-- Implementation links (mobile) -->
-	    <div class="btn-group">
-        <button class="btn btn-outline-secondary" data-bs-dismiss="offcanvas">Towards a virtual human </button>
-        <button class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split flex-grow-0" type="button" data-bs-toggle="collapse" data-bs-target="#collapseImplementation" aria-expanded="false" aria-controls="collapseImplementation" style="width: 3rem;"></button>
-      </div>
-      <div class="collapse" id="collapseImplementation">
-        <div class="d-flex flex-column ps-3 gap-2">
-          <button class="btn btn-light text-start" onclick="location.href='/explore_our_work'" data-bs-dismiss="offcanvas">Explore our work</button>
-          <button class="btn btn-light text-start" onclick="location.href='/training'" data-bs-dismiss="offcanvas">Training</button>
-          <button class="btn btn-light text-start" onclick="location.href='/impact'" data-bs-dismiss="offcanvas">Impact</button>
+      <!-- Implementation links (mobile) — pinned to bottom, collapse expands upward -->
+      <div class="mt-auto">
+        <div class="collapse" id="collapseImplementation">
+          <div class="d-flex flex-column ps-3 gap-2 mb-2">
+            <button class="btn btn-light text-start" onclick="location.href='/explore_our_work'" data-bs-dismiss="offcanvas">Process</button>
+            <button class="btn btn-light text-start" onclick="location.href='/training'" data-bs-dismiss="offcanvas">Training</button>
+            <button class="btn btn-light text-start" onclick="location.href='/impact'" data-bs-dismiss="offcanvas">Impact</button>
+          </div>
+        </div>
+        <div class="btn-group w-100">
+          <button class="btn btn-outline-secondary" onclick="location.href='{{ url_for('home') }}#about-section'" data-bs-dismiss="offcanvas">About</button>
+          <button class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split flex-grow-0" type="button" data-bs-toggle="collapse" data-bs-target="#collapseImplementation" aria-expanded="false" aria-controls="collapseImplementation" style="width: 3rem;"></button>
         </div>
       </div>
     <!-- end of implementation links (mobile) -->
@@ -309,7 +312,7 @@
               <li><a href="/tools" class="text-decoration-none link-vhppink fs-7 small">Tools</a></li>
               <li><a href="/casestudies" class="text-decoration-none link-vhppink fs-7 small">Case Studies</a></li>
               <li><a href="/data" class="text-decoration-none link-vhppink fs-7 small">Data</a></li>
-              <li><a href="/explore_our_work" class="text-decoration-none link-vhppink fs-7 small">Explore our work</a></li>
+              <li><a href="/explore_our_work" class="text-decoration-none link-vhppink fs-7 small">Process</a></li>
               <li><a href="/training" class="text-decoration-none link-vhppink fs-7 small">Training</a></li>
               <li><a href="/impact" class="text-decoration-none link-vhppink fs-7 small">Impact</a></li>
             </ul>

--- a/templates/home.html
+++ b/templates/home.html
@@ -149,8 +149,8 @@
 
 </section>
 <!-- About section: project description and mission -->
-<section class="container py-5" id="about-section">
-  <h2 class="mb-4"><strong>About the Virtual Human Platform</strong></h2>
+<section class="container py-5">
+  <h2 id="about-section" class="mb-4" style="scroll-margin-top: 6rem;"><strong>About the Virtual Human Platform</strong></h2>
 	<div>
 	<!---<h4>What is the Virtual Human Platform?</h4>-->
 	<p>The Virtual Human Platform (VHP) is a digital infrastructure that supports human-relevant risk assessment of chemicals and pharmaceuticals. By integrating  human-derived data, advanced in vitro models, and  computational tools, the VHP enables transparent, reproducible and mechanistically informed safety assessment moving beyond traditional animal testing. </p>
@@ -163,7 +163,13 @@
 	</ul></p>
 	<p>These case studies show how multiple New Approach Methodologies (NAMs) can be combined to address regulatory challenges and illustrate practices concerning data, model assumptions, and interpretation. </p>
 	<p>Developed in co-creation with academic, industrial, regulatory, and societal partners, the VHP supports the transition to animal-free, human-relevant safety assessment. We invite all stakeholders to explore, contribute, and help shape the future of risk assessment with us.</p>
-	<p>Learn more about VHP4Safety, the project behind the VHP, in <a href="/explore_our_work">“Explore our work”</a>. </p>
+	<emph>Learn more about VHP4Safety, the project behind the VHP in the following sections:</emph>
+  <div>
+    <div class="d-flex gap-3 mt-4">
+      <a href="{{ url_for('explore_our_work') }}#about-section" class="btn btn-outline-secondary">Process</a>
+      <a href="{{ url_for('training') }}#partners-section" class="btn btn-outline-secondary">Training</a>
+      <a href="{{ url_for('impact') }}#contact-section" class="btn btn-outline-secondary">Impact</a>
+    </div>
 	</div>
 </section>
 <!--<section class="container py-5" id="about-section">

--- a/templates/implementation/explore_our_work.html
+++ b/templates/implementation/explore_our_work.html
@@ -12,35 +12,15 @@
   rel="stylesheet"
 />
 
-<!-- Section A with internal navigation buttons to the implementation pages -->
-<section class="container pb-md-0 py-3 border-top border-bottom border-secondary rounded"> <!-- Section A start-->
-	<div id="implementation menu">
-		<div class="row py-3">
-        	<div class="col-md pb-2 d-flex align-items-stretch">
-          		<button class="btn w-100 text-white btn text-white btn-secondary" onclick="location.href='/explore_our_work'"><b>Explore our work</b></button>
-          	</div>
-        	<div class="col-md pb-2 d-flex align-items-stretch">
-          		<button class="btn w-100 text-white btn text-white btn-secondary" onclick="location.href='/training'"><b>Training</b></button>
-          	</div> 
-        	<div class="col-md pb-2 d-flex align-items-stretch">
-          		<button class="btn w-100 text-white btn text-white btn-secondary" onclick="location.href='/impact'"><b>Impact</b></button>
-          	</div>
-		</div></div>
-</section> <!-- Section A finish-->
 
 <!-- Here starts the section B with the main heading of the page and the introductory sentence -->
-<section class="container pt-md-3 pb-md-3 py-5"> <!-- Section B start-->
+<section class="container py-md-5 py-3"> <!-- Section B start-->
   	<div class="row align-items-center">
     	<div class="col-md-12">
-			<h1><span>Explore our work</span></h1>
-			<p>A comprehensive set of work practices implemented in the VHP4Safety project</p>
+			<h1><span>Process</span></h1>
+			<p class="text-secondary fs-5">A comprehensive set of work practices implemented in the VHP4Safety project</p>
     	</div>
   	</div>
-</section> <!-- Section B finish-->
-
-<!-- Here starts the section C containing the tabs and cards with information -->
-
-<section class="container pt-md-3 pb-md-3 py-5"> <!--Section C start -->
 	<div class="card"> <!--Start of divisions for tabs-->
   		<div class="card-header"> <!-- Start of headers of tabs, listed from 0 to n -->
     		<ul class="nav nav-tabs card-header-tabs" role="tablist">

--- a/templates/implementation/impact.html
+++ b/templates/implementation/impact.html
@@ -12,35 +12,15 @@
   rel="stylesheet"
 />
 
-<!-- Section A with internal navigation buttons to the implementation pages -->
-<section class="container pb-md-0 py-3 border-top border-bottom border-secondary rounded"> <!-- Section A start-->
-	<div id="implementation menu">
-		<div class="row py-3">
-        	<div class="col-md pb-2 d-flex align-items-stretch">
-          		<button class="btn w-100 text-white btn text-white btn-secondary" onclick="location.href='/explore_our_work'"><b>Explore our work</b></button>
-          	</div>
-        	<div class="col-md pb-2 d-flex align-items-stretch">
-          		<button class="btn w-100 text-white btn text-white btn-secondary" onclick="location.href='/training'"><b>Training</b></button>
-          	</div> 
-        	<div class="col-md pb-2 d-flex align-items-stretch">
-          		<button class="btn w-100 text-white btn text-white btn-secondary" onclick="location.href='/impact'"><b>Impact</b></button>
-          	</div>
-		</div></div>
-</section> <!-- Section A finish-->
-
 <!-- Here starts the section B with the main heading of the page and the introductory sentence -->
-<section class="container pt-md-3 pb-md-3 py-5"> <!-- Section B start-->
+<section class="container  py-md-5 py-3"> <!-- Section B start-->
   	<div class="row align-items-center">
     	<div class="col-md-12">
 			<h1><span>Impact</span></h1>
-			<p>Strategies for future use of the Virtual Human Platform focusing on innovation, acceptance, and impact creation</p>
+			<p class="text-secondary fs-5">Strategies for future use of the Virtual Human Platform focusing on innovation, acceptance, and impact creation</p>
     	</div>
   	</div>
-</section> <!-- Section B finish-->
 	
-<!-- Here starts the section C containing the tabs and cards with information -->
-
-<section class="container pt-md-3 pb-md-3 py-5"> <!--Section C start -->
 	<div class="card"> <!--Start of divisions for tabs-->
   		<div class="card-header"> <!-- Start of headers of tabs, listed from 0 to n -->
     		<ul class="nav nav-tabs card-header-tabs" role="tablist">

--- a/templates/implementation/training.html
+++ b/templates/implementation/training.html
@@ -12,35 +12,16 @@
   rel="stylesheet"
 />
 
-<!-- Section A with internal navigation buttons to the implementation pages -->
-<section class="container pb-md-0 py-3 border-top border-bottom border-secondary rounded"> <!-- Section A start-->
-	<div id="implementation menu">
-		<div class="row py-3">
-        	<div class="col-md pb-2 d-flex align-items-stretch">
-          		<button class="btn w-100 text-white btn text-white btn-secondary" onclick="location.href='/explore_our_work'"><b>Explore our work</b></button>
-          	</div>
-        	<div class="col-md pb-2 d-flex align-items-stretch">
-          		<button class="btn w-100 text-white btn text-white btn-secondary" onclick="location.href='/training'"><b>Training</b></button>
-          	</div> 
-        	<div class="col-md pb-2 d-flex align-items-stretch">
-          		<button class="btn w-100 text-white btn text-white btn-secondary" onclick="location.href='/impact'"><b>Impact</b></button>
-          	</div>
-		</div></div>
-</section> <!-- Section A finish-->
 
 <!-- Here starts the section B with the main heading of the page and the introductory sentence -->
-<section class="container pt-md-3 pb-md-3 py-5"> <!-- Section B start-->
+<section class="container  py-md-5 py-3"> <!-- Section B start-->
   	<div class="row align-items-center">
     	<div class="col-md-12">
 			<h1><span>Training</span></h1>
-			<p>Training and education to master the Virtual Human Platform and the principles of NAMs in human-based safety assessment</p>
+			<p class="text-secondary fs-5">Training and education to master the Virtual Human Platform and the principles of NAMs in human-based safety assessment</p>
     	</div>
   	</div>
-</section> <!-- Section B finish-->
 
-<!-- Here starts the section C containing the tabs and cards with information -->
-
-<section class="container pt-md-3 pb-md-3 py-5"> <!--Section C start -->
 	<div class="card"> <!--Start of divisions for tabs-->
   		<div class="card-header"> <!-- Start of headers of tabs, listed from 0 to n -->
     		<ul class="nav nav-tabs card-header-tabs" role="tablist">


### PR DESCRIPTION
 - Mobile offcanvas: rebuild the implementation menu as an About split-collapse pinned to the bottom (`mt-auto`). The collapse is placed before*the button in DOM order so it expands upward (dropup behavior); inner flex container gets `h-100` so the wrapper has space to push against. The label button links to `{{ url_for('home') }}#about-section`.
 
<img width="288" height="828" alt="Screenshot 2026-05-13 at 02 40 47" src="https://github.com/user-attachments/assets/d9a5007f-b195-475f-ba7f-5ba4aa900207" />

  - Desktop nav: replace the bare hamburger-style implementation dropdown with a About split button matching the styling of the other nav groups; dropdown items link to Process / Training / Impact.
  - Rename "Explore our work" → "Process" across desktop dropdown, mobile dropup, footer, page heading, and the home about section link. URL/route (`/explore_our_work`) is unchanged. 
  - Move `id="about-section"` from the `<section>` to the `<h2>` and add `scroll-margin-top: 6rem` so anchor jumps land on the heading instead of behind the fixed navbar.
  - Home about section: replace the trailing single-link paragraph with a three-button row (Process / Training / Impact).


<img width="1467" height="541" alt="Screenshot 2026-05-13 at 02 44 38" src="https://github.com/user-attachments/assets/f9918cae-465e-411c-b770-2f34bce31a33" />


  - Implementation pages (`explore_our_work.html`, `training.html`, `impact.html`): drop the duplicated in-page nav-button row (already covered by the global nav), flatten the nested section wrappers, restyle lead copy as `text-secondary fs-5`.