### PR TITLE
fix(.gitattributes): mark static JS files as binary to prevent line-e…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 *.html text eol=lf
 *.css  text eol=lf
 *.js   text eol=lf
+static/js/j2s/**/*.js binary
 *.json text eol=lf
 *.md   text eol=lf
 *.txt  text eol=lf


### PR DESCRIPTION
…nding conversion

partially addresses #403
