### PR TITLE
refactor(design): color map for consistency with Process Flow 

### DIFF
--- a/bootstrap-custom/custom.scss
+++ b/bootstrap-custom/custom.scss
@@ -78,6 +78,20 @@ $link-decoration: none;
 // 5️⃣ Import the rest of Bootstrap (it now uses your colors)
 @import "bootstrap/scss/bootstrap";
 
+// Force white text on vhpblue solid buttons (override Bootstrap's auto-calculated contrast)
+.btn-vhpblue {
+  --bs-btn-color: #fff;
+  --bs-btn-hover-color: #fff;
+  --bs-btn-active-color: #fff;
+  --bs-btn-disabled-color: #fff;
+}
+
+// Force white text on vhpblue outline buttons when hovered/active (filled state)
+.btn-outline-vhpblue {
+  --bs-btn-hover-color: #fff;
+  --bs-btn-active-color: #fff;
+}
+
 /* Grid layout for Search/Filter Results */
 .results-section {
   min-height: 400px;

--- a/static/css/bootstrap-custom.css
+++ b/static/css/bootstrap-custom.css
@@ -13154,6 +13154,18 @@ textarea.form-control-lg {
     display: none !important;
   }
 }
+.btn-vhpblue {
+  --bs-btn-color: #fff;
+  --bs-btn-hover-color: #fff;
+  --bs-btn-active-color: #fff;
+  --bs-btn-disabled-color: #fff;
+}
+
+.btn-outline-vhpblue {
+  --bs-btn-hover-color: #fff;
+  --bs-btn-active-color: #fff;
+}
+
 /* Grid layout for Search/Filter Results */
 .results-section {
   min-height: 400px;

--- a/templates/Safety_Assessment_Workflow.html
+++ b/templates/Safety_Assessment_Workflow.html
@@ -11,12 +11,6 @@
   href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"
   rel="stylesheet"
 />
-<!-- Tab section: navigation to Tools, Case Studies, Data -->
-<section class="img-fluid py-5">
-  <div class="container">
-    <div class="py-4">
-      <div class="row gy-4">
-</section> 
 <!-- Process flow description -->
 <section class="container py-5" id="about-section">
   <h1 class="mb-4 text-vhppurple"><strong>The Safety Assessment Workflow</strong></h1>

--- a/templates/Safety_Assessment_Workflow.html
+++ b/templates/Safety_Assessment_Workflow.html
@@ -12,19 +12,19 @@
   rel="stylesheet"
 />
 <!-- Tab section: navigation to Tools, Case Studies, Data -->
-<section class="bg-vhpblue img-fluid py-5">
+<section class="img-fluid py-5">
   <div class="container">
     <div class="py-4">
       <div class="row gy-4">
 </section> 
 <!-- Process flow description -->
 <section class="container py-5" id="about-section">
-  <h2 class="mb-4"><strong>The Safety Assessment Workflow</strong></h2>
+  <h1 class="mb-4 text-vhppurple"><strong>The Safety Assessment Workflow</strong></h1>
   <p>
     The Safety Assessment Workflow is a combination of tools and data selected and integrated to perform generic risk assessment.
     The Flow consists of five Steps.
   </p>
-<h2 class="mb-4"><strong>The five Safety Assessment Workflow Steps</strong></h2>
+<h2 class="mb-4 text-vhppurple"><strong>The five Safety Assessment Workflow Steps</strong></h2>
   <p>
     Each step is one of the components of the Safety Assessment Workflow and categorizes processes that users can perform with the Virtual Human Platform.
     Each step is named after a term from the VHP4Safety Glossary.

--- a/templates/base.html
+++ b/templates/base.html
@@ -162,9 +162,9 @@
     </div>
 
     <div class="btn-group"  role="group">
-      <button class="btn btn-vhplight-green text-nowrap" style="width:120px" onclick="location.href='/methods'"
+      <button class="btn btn-vhpblue text-nowrap" style="width:120px" onclick="location.href='/methods'"
         type="button">Methods</button>
-      <button type="button" style="width:30px" class="btn btn-vhplight-green dropdown-toggle dropdown-toggle-split" id="methodsMenuBtn" data-bs-toggle="dropdown" aria-expanded="false">
+      <button type="button" style="width:30px" class="btn btn-vhpblue dropdown-toggle dropdown-toggle-split" id="methodsMenuBtn" data-bs-toggle="dropdown" aria-expanded="false">
         <span class="visually-hidden">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu dropdown-menu-end" id="methodsMenu" aria-labelledby="methodsMenuBtn" data-page-size="12">
@@ -174,7 +174,7 @@
 
 
     <!-- Data Button -->
-    <button class="btn btn-vhpteal text-nowrap" style="width: 150px;" onclick="location.href='/data'" type="button">Data</button>
+    <button class="btn btn-vhpblue text-nowrap" style="width: 150px;" onclick="location.href='/data'" type="button">Data</button>
 
   </div>
 </nav>
@@ -253,9 +253,9 @@
 
       <!-- Methods button -->
       <div class="btn-group">
-        <button class="btn btn-vhplight-green" onclick="location.href='/methods'" data-bs-dismiss="offcanvas">Methods</button>
+        <button class="btn btn-vhpblue" onclick="location.href='/methods'" data-bs-dismiss="offcanvas">Methods</button>
         <!-- Collapse toggle -->
-        <button class="btn btn-vhplight-green dropdown-toggle dropdown-toggle-split flex-grow-0" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMethods" aria-expanded="false" aria-controls="collapseMethods" style="width: 3rem;"></button>
+        <button class="btn btn-vhpblue dropdown-toggle dropdown-toggle-split flex-grow-0" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMethods" aria-expanded="false" aria-controls="collapseMethods" style="width: 3rem;"></button>
       </div>
 
       <!-- dropdownitems with Javier's logic-->
@@ -270,7 +270,7 @@
       </div>
 
       <!-- Data button -->
-      <button class="btn btn-vhpteal mt-2" onclick="location.href='/data'" data-bs-dismiss="offcanvas">Data</button>
+      <button class="btn btn-vhpblue mt-2" onclick="location.href='/data'" data-bs-dismiss="offcanvas">Data</button>
 
       <!-- Glossary Toggle Switch (mobile) -->
       <div class="form-check form-switch mt-2" data-vhp-glossary-skip>

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -129,7 +129,7 @@
                     <div class="card-footer btn-group bg-white border-0 py-3" role="group">
                             <a href="{{ url_for('data_detail', dataid=study.accession) }}" style="min-width:70px" class="btn btn-vhpblue" role="button" data-bs-toggle="tooltip" data-bs-title="View details"><i class="bi bi-info-circle"></i></a>
                             {% if study.url%}
-                            <a href="{{ study.url}}" class="btn btn-outline-vhpblue d-inline" target="_blank"><i class="bi bi-box-arrow-up-right pe-1"></i> View in BioStudies</a>
+                            <a href="{{ study.url}}" class="btn btn-outline-vhpblue d-inline" target="_blank" rel="noopener"><i class="bi bi-box-arrow-up-right pe-1"></i> View in BioStudies</a>
                             {% endif%}
 
                             {% if study.metadata.rocrate_url %}
@@ -171,7 +171,7 @@
                     <div class="card-footer btn-group bg-white border-0 py-3" role="group">
                             <a href="{{ url_for('data_detail', dataid=dataset.id) }}" style="min-width:70px" class="btn btn-vhpblue" role="button" data-bs-toggle="tooltip" data-bs-title="View details"><i class="bi bi-info-circle"></i></a>
                             {% if dataset.doi_url%}
-                            <a href="{{ dataset.doi_url}}" class="btn btn-outline-vhpblue d-inline" target="_blank"><i class="bi bi-box-arrow-up-right pe-1"></i> View on Zenodo</a>
+                            <a href="{{ dataset.doi_url}}" class="btn btn-outline-vhpblue d-inline" target="_blank" rel="noopener"><i class="bi bi-box-arrow-up-right pe-1"></i> View on Zenodo</a>
                             {% endif%}
                             {% if dataset.links.archive%}
                             <a href="{{ dataset.links.archive}}" class="btn btn-outline-secondary d-inline view-details-btn"><i class="bi bi-box-fill pe-1"></i>{%if dataset.parsed_metadata.is_rocrate %}RO-Crate{% else %}Archive{% endif %}</a>

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -5,7 +5,7 @@
 <section class="container py-md-5 py-3 d-flex flex-column min-vh-100">
     <!-- Page Title and Description -->
     <div data-vhp-glossary-skip class="">
-        <h1><span class="text-vhpteal" id="collection-name">{{ collection_name or 'Data catalog' }} Data</span></h1>
+        <h1><span class="text-vhpblue" id="collection-name">{{ collection_name or 'Data catalog' }} Data</span></h1>
         <p class="text-secondary fs-5">Explore datasets generated or used in <span id="collection-name-sub">{{ collection_name }} and hosted on BioStudies or Zenodo archives.</span></p>
     </div>
 
@@ -17,7 +17,7 @@
             <input type="hidden" name="filter_regulatory_question" id="filter_regulatory_question" value="{{ filter_regulatory_question or '' }}" />
             <input type="hidden" name="filter_flow_step" id="filter_flow_step" value="{{ filter_flow_step or '' }}" />
             <div class="btn-group" role="group" aria-label="Search and filter buttons">
-                <button type="submit" class="btn btn-outline-vhpteal">Search</button>
+                <button type="submit" class="btn btn-outline-vhpblue">Search</button>
                 <a href="{{ url_for('data') }}" class="btn btn-outline-danger text-nowrap">Clear</a>
                 <button type="button" id="filter-toggle-btn" class="btn btn-outline-secondary">Filters</button>
             </div>
@@ -44,13 +44,13 @@
                         Flow Step
                     </button>
                     <ul class="dropdown-menu">
-                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="ADME" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['ADME'] }}">ADME <i class="bi bi-question-circle text-vhpteal"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="Chemical Information" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Chemical Information'] }}">Chemical Information <i class="bi bi-question-circle text-vhpteal"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="General" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['General'] }}">General <i class="bi bi-question-circle text-vhpteal"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="Hazard Assessment" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Hazard Assessment'] }}">Hazard Assessment <i class="bi bi-question-circle text-vhpteal"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="External exposure" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['External exposure'] }}">External exposure <i class="bi bi-question-circle text-vhpteal"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="Generic" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Generic'] }}">Generic <i class="bi bi-question-circle text-vhpteal"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="Other" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Other'] }}">Other <i class="bi bi-question-circle text-vhpteal"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="ADME" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['ADME'] }}">ADME <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="Chemical Information" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Chemical Information'] }}">Chemical Information <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="General" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['General'] }}">General <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="Hazard Assessment" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Hazard Assessment'] }}">Hazard Assessment <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="External exposure" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['External exposure'] }}">External exposure <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="Generic" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Generic'] }}">Generic <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="Other" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Other'] }}">Other <i class="bi bi-question-circle text-vhpblue"></i></a></li>
                     </ul>
                 </div>
                 
@@ -60,12 +60,12 @@
                         Regulatory Question
                     </button>
                     <ul class="dropdown-menu">
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Kidney Case Study (a)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Kidney Case Study (a)'] }}">Kidney Case Study (a) <i class="bi bi-question-circle text-vhpteal"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Kidney Case Study (b)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Kidney Case Study (b)'] }}">Kidney Case Study (b) <i class="bi bi-question-circle text-vhpteal"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Parkinson Case Study (a)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Parkinson Case Study (a)'] }}">Parkinson Case Study (a) <i class="bi bi-question-circle text-vhpteal"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Parkinson Case Study (b)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Parkinson Case Study (b)'] }}">Parkinson Case Study (b) <i class="bi bi-question-circle text-vhpteal"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Thyroid Case Study (a)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Thyroid Case Study (a)'] }}">Thyroid Case Study (a) <i class="bi bi-question-circle text-vhpteal"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Thyroid Case Study (b)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Thyroid Case Study (b)'] }}">Thyroid Case Study (b) <i class="bi bi-question-circle text-vhpteal"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Kidney Case Study (a)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Kidney Case Study (a)'] }}">Kidney Case Study (a) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Kidney Case Study (b)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Kidney Case Study (b)'] }}">Kidney Case Study (b) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Parkinson Case Study (a)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Parkinson Case Study (a)'] }}">Parkinson Case Study (a) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Parkinson Case Study (b)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Parkinson Case Study (b)'] }}">Parkinson Case Study (b) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Thyroid Case Study (a)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Thyroid Case Study (a)'] }}">Thyroid Case Study (a) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Thyroid Case Study (b)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Thyroid Case Study (b)'] }}">Thyroid Case Study (b) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
                     </ul>
                 </div>
             </div>
@@ -81,7 +81,7 @@
             </div>
             
             <div class="">
-                <button id="apply-filter-btn" class="btn btn-sm btn-vhpteal mt-2">Apply</button>
+                <button id="apply-filter-btn" class="btn btn-sm btn-vhpblue mt-2">Apply</button>
                 <button id="clear-filter-btn" class="btn btn-sm btn-outline-danger mt-2">Clear</button>
             </div>
         </div>
@@ -95,9 +95,9 @@
         <strong>Filters Active:</strong> Showing {{ hits_returned }} results
         {% if not page_size_met %}(fetched {{ pages_fetched }} page(s), timeout reached){% endif %}
         | 
-        {% if filter_case_study %}<span class="badge bg-vhpteal">Case Study: {{ filter_case_study }}</span> {% endif %}
-        {% if filter_flow_step %}<span class="badge bg-vhpteal">Flow Step: {{ filter_flow_step }}</span> {% endif %}
-        {% if filter_regulatory_question %}<span class="badge bg-vhpteal">Regulatory Question: {{ filter_regulatory_question }}</span> {% endif %}
+        {% if filter_case_study %}<span class="badge bg-vhppink-distinct text-white">Case Study: {{ filter_case_study }}</span> {% endif %}
+        {% if filter_flow_step %}<span class="badge bg-vhppurple">Flow Step: {{ filter_flow_step }}</span> {% endif %}
+        {% if filter_regulatory_question %}<span class="badge bg-vhppink-distinct">Regulatory Question: {{ filter_regulatory_question }}</span> {% endif %}
     </div>
     {% endif %}
 
@@ -114,9 +114,9 @@
                         <span class="badge bg-vhplight-blue text-secondary rounded-pill align-content-center">{{ study.type or 'unknown' }}</span>
                     </div>
                     <div class = "card-header bg-white align-items-center">
-                            {% if study.metadata.case_study%}<a role="button" href="{{url_for('casestudy', case=study.metadata.case_study|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhpteal rounded-pill border border-vhpteal d-inline-flex align-items-center text-wrap">Case Study: {{study.metadata.case_study|capitalize }}</a>{%endif%}
-                            {% if study.metadata.regulatory_question%}<a role="button" href="{{url_for('casestudy', case=study.metadata.case_study|lower, question=study.metadata.regulatory_question )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhpteal rounded-pill border border-vhpteal d-inline-flex align-items-center text-wrap">Regulatory Question: {{study.metadata.regulatory_question}}</a>{%endif%}
-                            {% if study.metadata.flow_step%}<a role="button" href="{{url_for('casestudy', case=study.metadata.case_study|lower, question=study.metadata.regulatory_question, step=study.metadata.flow_step )}}"  style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhpteal rounded-pill border border-vhpteal d-inline-flex align-items-center text-wrap">Flow Step: {{study.metadata.flow_step}}</a>{%endif%}
+                            {% if study.metadata.case_study%}<a role="button" href="{{url_for('casestudy', case=study.metadata.case_study|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">Case Study: {{study.metadata.case_study|capitalize }}</a>{%endif%}
+                            {% if study.metadata.regulatory_question%}<a role="button" href="{{url_for('casestudy', case=study.metadata.case_study|lower, question=study.metadata.regulatory_question )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">Regulatory Question: {{study.metadata.regulatory_question}}</a>{%endif%}
+                            {% if study.metadata.flow_step%}<a role="button" href="{{url_for('casestudy', case=study.metadata.case_study|lower, question=study.metadata.regulatory_question, step=study.metadata.flow_step )}}"  style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppurple rounded-pill border border-vhppurple d-inline-flex align-items-center text-wrap">Flow Step: {{study.metadata.flow_step}}</a>{%endif%}
                     </div>
                     <div class="card-body">
                         <h5 class="card-title" style="word-break: break-word;">
@@ -127,9 +127,9 @@
                         </div>
                     </div>
                     <div class="card-footer btn-group bg-white border-0 py-3" role="group">
-                            <a href="{{ url_for('data_detail', dataid=study.accession) }}" style="min-width:70px" class="btn btn-vhpteal" role="button" data-bs-toggle="tooltip" data-bs-title="View details"><i class="bi bi-info-circle"></i></a>
+                            <a href="{{ url_for('data_detail', dataid=study.accession) }}" style="min-width:70px" class="btn btn-vhpblue" role="button" data-bs-toggle="tooltip" data-bs-title="View details"><i class="bi bi-info-circle"></i></a>
                             {% if study.url%}
-                            <a href="{{ study.url}}" class="btn btn-outline-vhpteal d-inline" target="_blank"><i class="bi bi-box-arrow-up-right pe-1"></i> View in BioStudies</a>
+                            <a href="{{ study.url}}" class="btn btn-outline-vhpblue d-inline" target="_blank"><i class="bi bi-box-arrow-up-right pe-1"></i> View in BioStudies</a>
                             {% endif%}
 
                             {% if study.metadata.rocrate_url %}
@@ -169,9 +169,9 @@
                         </div>
                     </div>
                     <div class="card-footer btn-group bg-white border-0 py-3" role="group">
-                            <a href="{{ url_for('data_detail', dataid=dataset.id) }}" style="min-width:70px" class="btn btn-vhpteal" role="button" data-bs-toggle="tooltip" data-bs-title="View details"><i class="bi bi-info-circle"></i></a>
+                            <a href="{{ url_for('data_detail', dataid=dataset.id) }}" style="min-width:70px" class="btn btn-vhpblue" role="button" data-bs-toggle="tooltip" data-bs-title="View details"><i class="bi bi-info-circle"></i></a>
                             {% if dataset.doi_url%}
-                            <a href="{{ dataset.doi_url}}" class="btn btn-outline-vhpteal d-inline" target="_blank"><i class="bi bi-box-arrow-up-right pe-1"></i> View on Zenodo</a>
+                            <a href="{{ dataset.doi_url}}" class="btn btn-outline-vhpblue d-inline" target="_blank"><i class="bi bi-box-arrow-up-right pe-1"></i> View on Zenodo</a>
                             {% endif%}
                             {% if dataset.links.archive%}
                             <a href="{{ dataset.links.archive}}" class="btn btn-outline-secondary d-inline view-details-btn"><i class="bi bi-box-fill pe-1"></i>{%if dataset.parsed_metadata.is_rocrate %}RO-Crate{% else %}Archive{% endif %}</a>
@@ -228,7 +228,7 @@
                 'flow-step': 'Flow Step',
                 'reg-question': 'Reg. Question'
             },
-            badgeClass: 'badge rounded-pill text-bg-vhpteal',
+            badgeClass: 'badge rounded-pill text-bg-vhpblue',
             showFilterPanel: {% if filter_case_study or filter_flow_step or filter_regulatory_question %}true{% else %}false{% endif %}
         });
     });

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -895,7 +895,7 @@
      {% if record.type=="study"%}
     <div class="card-footer">
      
-        {% if data.metadata.case_study%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">Case Study: BLUE {{data.metadata.case_study|capitalize }}</a>{%endif%}
+        {% if data.metadata.case_study%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">Case Study: {{data.metadata.case_study|capitalize }}</a>{%endif%}
         {% if data.metadata.regulatory_question%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower, question=data.metadata.regulatory_question )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">Regulatory Question: {{data.metadata.regulatory_question}}</a>{%endif%}
         {% if data.metadata.flow_step%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower, question=data.metadata.regulatory_question, step=data.metadata.flow_step )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppurple rounded-pill border border-vhppurple d-inline-flex align-items-center text-wrap">Flow Step: {{data.metadata.flow_step}}</a>{%endif%}
 

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -62,7 +62,7 @@
    --------------------------- #}
 <section class="container py-5">
   <div class="pb-2">
-    <h1><span class="text-vhpteal">{{ val(record.title, 'Dataset') }}</span></h1>
+    <h1><span class="text-vhpblue">{{ val(record.title, 'Dataset') }}</span></h1>
     {% if record.description %}
       <p class="text-secondary">{{ record.description }}</p>
     {% endif %}
@@ -72,7 +72,7 @@
     <div class="card-header">
       <ul class="nav nav-tabs card-header-tabs" role="tablist">
         <li class="nav-item" role="presentation">
-          <a class="nav-link text-vhpteal  active"
+          <a class="nav-link text-vhpblue  active"
              id="tab-general-link"
              data-bs-toggle="tab"
              href="#tab-general"
@@ -82,7 +82,7 @@
         </li>
     {% if record.type == "study" %}
         <li class="nav-item" role="presentation">
-          <a class="nav-link text-vhpteal "
+          <a class="nav-link text-vhpblue "
              id="tab-biomodel-link"
              data-bs-toggle="tab"
              href="#tab-biomodel"
@@ -92,7 +92,7 @@
         </li>
 
         <li class="nav-item" role="presentation">
-          <a class="nav-link text-vhpteal "
+          <a class="nav-link text-vhpblue "
              id="tab-chemical-link"
              data-bs-toggle="tab"
              href="#tab-chemical"
@@ -102,7 +102,7 @@
         </li>
 
         <li class="nav-item" role="presentation">
-          <a class="nav-link text-vhpteal "
+          <a class="nav-link text-vhpblue "
              id="tab-exposure-link"
              data-bs-toggle="tab"
              href="#tab-exposure"
@@ -112,7 +112,7 @@
         </li>
 
         <li class="nav-item" role="presentation">
-          <a class="nav-link text-vhpteal "
+          <a class="nav-link text-vhpblue "
              id="tab-endpoint-link"
              data-bs-toggle="tab"
              href="#tab-endpoint"
@@ -122,7 +122,7 @@
         </li>
 
         <li class="nav-item" role="presentation">
-          <a class="nav-link text-vhpteal "
+          <a class="nav-link text-vhpblue "
              id="tab-analysis-link"
              data-bs-toggle="tab"
              href="#tab-analysis"
@@ -134,7 +134,7 @@
     {%endif%}
 
         <li class="nav-item" role="presentation">
-          <a class="nav-link text-vhpteal "
+          <a class="nav-link text-vhpblue "
              id="tab-pubs-link"
              data-bs-toggle="tab"
              href="#tab-publications"
@@ -143,7 +143,7 @@
              aria-selected="false">Publications</a>
         </li>
         <li class="nav-item" role="presentation">
-          <a class="nav-link text-vhpteal "
+          <a class="nav-link text-vhpblue "
              id="tab-how-to-cite-link"
              data-bs-toggle="tab"
              href="#tab-how-to-cite"
@@ -272,7 +272,7 @@
                     <ul class="list-group list-group-flush">
                       {% for f in record.files %}
                         <li class="list-group-item d-flex align-items-start gap-2">
-                          <i class="bi bi-file-earmark text-vhpteal"></i>
+                          <i class="bi bi-file-earmark text-vhpblue"></i>
                           <span>
                           {% if f.url %}
                             <a href="{{ f.url }}" target="_blank" rel="noopener">{{ val(f.name) }}</a>
@@ -305,7 +305,7 @@
                     <ul class="list-group list-group-flush">
                       {% for a in record.authors %}
                         <li class="list-group-item  d-flex align-items-start gap-2">
-                          <i class="bi bi-person-circle text-vhpteal"></i>
+                          <i class="bi bi-person-circle text-vhpblue"></i>
 
                           <span class="small">
                             <span class="fw-semibold">{{ val(a.name) }}</span>
@@ -353,7 +353,7 @@
                     <ul class="list-group list-group-flush">
                       {% for f in record.funding %}
                         <li class="list-group-item d-flex align-items-start gap-2">
-                          <i class="bi bi-bank text-vhpteal"></i>
+                          <i class="bi bi-bank text-vhpblue"></i>
 
                           <span class="small">
                             <span class="fw-semibold">{{ val(f.funder) }}</span>
@@ -417,7 +417,7 @@
                     <div class="d-flex align-items-start gap-3">
 
                       <div class="flex-shrink-0 pt-1">
-                        <i class="bi bi-tag text-vhpteal fs-4"></i>
+                        <i class="bi bi-tag text-vhpblue fs-4"></i>
                       </div>
 
                       <div class="w-100">
@@ -432,7 +432,7 @@
                             <span class="text-muted">RRID:</span>
                             {% if ns_bm.rrid_url %}
                               <a href="{{ ns_bm.rrid_url }}" target="_blank" rel="noopener" class="text-decoration-none">
-                                <i class="bi bi-link-45deg text-vhpteal"></i> {{ ns_bm.rrid }}
+                                <i class="bi bi-link-45deg text-vhpblue"></i> {{ ns_bm.rrid }}
                               </a>
                             {% else %}
                               {{ ns_bm.rrid }}
@@ -555,7 +555,7 @@
                         </div>
                       {% else %}
                         <div class="flex-shrink-0 pt-1">
-                          <i class="bi bi-droplet-fill text-vhpteal fs-4"></i>
+                          <i class="bi bi-droplet-fill text-vhpblue fs-4"></i>
                         </div>
                       {% endif %}
 
@@ -580,7 +580,7 @@
                             <span class="text-muted">CAS:</span>
                             <a href="https://commonchemistry.cas.org/results?q={{ ns.cas|urlencode }}"
                               target="_blank" rel="noopener" class="text-decoration-none">
-                              <i class="bi bi-link-45deg text-vhpteal"></i> {{ ns.cas }}
+                              <i class="bi bi-link-45deg text-vhpblue"></i> {{ ns.cas }}
                             </a>
                           {% endif %}
 
@@ -590,7 +590,7 @@
                             <span class="text-muted">PubChem:</span>
                             <a href="https://pubchem.ncbi.nlm.nih.gov/compound/{{ ns.cid|urlencode }}"
                               target="_blank" rel="noopener" class="text-decoration-none">
-                              <i class="bi bi-link-45deg text-vhpteal"></i> CID {{ ns.cid }}
+                              <i class="bi bi-link-45deg text-vhpblue"></i> CID {{ ns.cid }}
                             </a>
                           {% endif %}
 
@@ -600,7 +600,7 @@
                             <span class="text-muted">CompoundCloud:</span>
                             {% if ns.cc_url %}
                               <a href="{{ ns.cc_url }}" target="_blank" rel="noopener" class="text-decoration-none">
-                                <i class="bi bi-link-45deg text-vhpteal"></i> {{ ns.cc_id }}
+                                <i class="bi bi-link-45deg text-vhpblue"></i> {{ ns.cc_id }}
                               </a>
                             {% else %}
                               {{ ns.cc_id }}
@@ -652,7 +652,7 @@
                     <div class="d-flex align-items-start gap-3">
 
                       <div class="flex-shrink-0 pt-1">
-                        <i class="bi bi-clock-history text-vhpteal fs-4"></i>
+                        <i class="bi bi-clock-history text-vhpblue fs-4"></i>
                       </div>
 
                       <div class="w-100">
@@ -704,7 +704,7 @@
                 {{ ns_bio.bioassay }}
               {% endif %}
               {% if ns_bio.bioassay_ontology %}
-                <span class="badge bg-vhpteal rounded-pill ms-1" style="font-size:0.7em;">{{ ns_bio.bioassay_ontology }}</span>
+                <span class="badge bg-vhpblue rounded-pill ms-1" style="font-size:0.7em;">{{ ns_bio.bioassay_ontology }}</span>
               {% endif %}
             </div>
           </div>
@@ -733,7 +733,7 @@
                     <div class="d-flex align-items-start gap-3">
 
                       <div class="flex-shrink-0 pt-1">
-                        <i class="bi bi-pc-display-horizontal text-vhpteal fs-4"></i>
+                        <i class="bi bi-pc-display-horizontal text-vhpblue fs-4"></i>
                       </div>
 
                       <div class="w-100">
@@ -791,7 +791,7 @@
               <ul class="list-group list-group-flush">
                 {% for ev in ns_bio.aop_events %}
                   <li class="list-group-item d-flex align-items-start gap-2">
-                    <i class="bi bi-arrow-right-circle text-vhpteal"></i>
+                    <i class="bi bi-arrow-right-circle text-vhpblue"></i>
                     <span class="small">
                       {% if ev.url %}
                         <a href="{{ ev.url }}" target="_blank" rel="noopener">{{ ev.value }}</a>
@@ -824,7 +824,7 @@
                   <div class="card-body p-3">
                     <div class="d-flex align-items-start gap-3">
                       <div class="flex-shrink-0 pt-1">
-                        <i class="bi bi-book text-vhpteal fs-4"></i>
+                        <i class="bi bi-book text-vhpblue fs-4"></i>
                       </div>
                       <div class="w-100">
                         <div class="pub-citation small">
@@ -832,7 +832,7 @@
                         </div>
                         {% if pub.doi %}
                           <div class="small text-muted mt-1">
-                            <i class="bi bi-link-45deg text-vhpteal"></i>
+                            <i class="bi bi-link-45deg text-vhpblue"></i>
                             <a href="https://doi.org/{{ pub.doi }}" target="_blank" rel="noopener">
                               https://doi.org/{{ pub.doi }}
                             </a>
@@ -863,7 +863,7 @@
             <div class="card-body p-3">
               <div class="d-flex align-items-start gap-3">
                 <div class="flex-shrink-0 pt-1">
-                  <i class="bi bi-quote text-vhpteal fs-4"></i>
+                  <i class="bi bi-quote text-vhpblue fs-4"></i>
                 </div>
                 <div class="w-100">
                   <div class="d-flex align-items-start gap-2">
@@ -895,9 +895,9 @@
      {% if record.type=="study"%}
     <div class="card-footer">
      
-        {% if data.metadata.case_study%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhpteal rounded-pill border border-vhpteal d-inline-flex align-items-center text-wrap">Case Study: {{data.metadata.case_study|capitalize }}</a>{%endif%}
-        {% if data.metadata.regulatory_question%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower, question=data.metadata.regulatory_question )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhpteal rounded-pill border border-vhpteal d-inline-flex align-items-center text-wrap">Regulatory Question: {{data.metadata.regulatory_question}}</a>{%endif%}
-        {% if data.metadata.flow_step%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower, question=data.metadata.regulatory_question, step=data.metadata.flow_step )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhpteal rounded-pill border border-vhpteal d-inline-flex align-items-center text-wrap">Flow Step: {{data.metadata.flow_step}}</a>{%endif%}
+        {% if data.metadata.case_study%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">Case Study: BLUE {{data.metadata.case_study|capitalize }}</a>{%endif%}
+        {% if data.metadata.regulatory_question%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower, question=data.metadata.regulatory_question )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">Regulatory Question: {{data.metadata.regulatory_question}}</a>{%endif%}
+        {% if data.metadata.flow_step%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower, question=data.metadata.regulatory_question, step=data.metadata.flow_step )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppurple rounded-pill border border-vhppurple d-inline-flex align-items-center text-wrap">Flow Step: {{data.metadata.flow_step}}</a>{%endif%}
 
     </div>
       {% endif %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -41,7 +41,7 @@
   <!-- Workflow section -->
   <div class="row mt-5 text-justify">
     <div class="col-12 mb-3">
-      <h3 class="text-vhpblue">Safety Assessment Workflow </h3>
+      <h3 class="text-vhppurple">Safety Assessment Workflow </h3>
       <p class="text-muted">
         The Virtual Human Platform implements a generic safety assessment as a six-step process.
       </p>
@@ -50,32 +50,32 @@
     <div class="col-12">
       <div class="row row-cols-1 row-cols-md-6 g-3">
         <div class="col d-grid">
-          <div class="btn btn-vhpblue text-white d-flex align-items-center justify-content-center text-center">
+          <div class="btn btn-vhppurple text-white d-flex align-items-center justify-content-center text-center">
             Hazard & Chemical Characterization
           </div>
         </div>
         <div class="col d-grid">
-          <div class="btn btn-vhpblue text-white d-flex align-items-center justify-content-center text-center">
+          <div class="btn btn-vhppurple text-white d-flex align-items-center justify-content-center text-center">
             External Exposure
           </div>
         </div>
         <div class="col d-grid">
-          <div class="btn btn-vhpblue text-white d-flex align-items-center justify-content-center text-center">
+          <div class="btn btn-vhppurple text-white d-flex align-items-center justify-content-center text-center">
             Toxicokinetics
           </div>
         </div>
         <div class="col d-grid">
-          <div class="btn btn-vhpblue text-white d-flex align-items-center justify-content-center text-center">
+          <div class="btn btn-vhppurple text-white d-flex align-items-center justify-content-center text-center">
             Internal Exposure
           </div>
         </div>
         <div class="col d-grid">
-          <div class="btn btn-vhpblue text-white d-flex align-items-center justify-content-center text-center">
+          <div class="btn btn-vhppurple text-white d-flex align-items-center justify-content-center text-center">
             AOP
           </div>
         </div>
         <div class="col d-grid">
-          <div class="btn btn-vhpblue text-white d-flex align-items-center justify-content-center text-center">
+          <div class="btn btn-vhppurple text-white d-flex align-items-center justify-content-center text-center">
             Adverse Outcome
           </div>
         </div>
@@ -128,15 +128,15 @@
         <!-- Methods card -->
         <div class="col-md-3">
 
-          <div class="card text-center  card-button card-button-vhplight-green h-100 shadow-sm" onclick="location.href='/methods'">
-            <div class="card-header bg-vhplight-green ">
-              <h5 class="card-title text-black m-0">Methods</h5>
+          <div class="card text-center  card-button card-button-vhpblue h-100 shadow-sm" onclick="location.href='/methods'">
+            <div class="card-header bg-vhpblue ">
+              <h5 class="card-title text-white m-0">Methods</h5>
             </div>
             <div class="card-body">
             Select an in vitro method to perform your safety assessment.
             </div>
             <div class="card-footer text-body-secondary">
-              <span class="badge rounded-pill bg-vhplight-green text-white">{{18}}</span> methods
+              <span class="badge rounded-pill bg-vhpblue text-white">{{18}}</span> methods
             </div>
           </div>
         </div>
@@ -145,8 +145,8 @@
         <!-- Data card -->
         <div class="col-md-3">
 
-          <div class="card text-center card-button card-button-vhpteal h-100 shadow-sm" onclick="location.href='/data'">
-            <div class="card-header bg-vhpteal ">
+          <div class="card text-center card-button card-button-vhpblue h-100 shadow-sm" onclick="location.href='/data'">
+            <div class="card-header bg-vhpblue ">
               <h5 class="card-title text-white m-0">Data</h5>
             </div>
             <div class="card-body"  style="text-align: justify;">
@@ -154,7 +154,7 @@
                 workflows as efficiently as possible.
             </div>
             <div class="card-footer text-body-secondary">
-              <span class="badge rounded-pill bg-vhpteal text-white">{{num_datasets}}</span> datasets 
+              <span class="badge rounded-pill bg-vhpblue text-white">{{num_datasets}}</span> datasets 
             </div>
           </div>
         </div>

--- a/templates/methods/method.html
+++ b/templates/methods/method.html
@@ -130,11 +130,11 @@
             <div class="mt-3">
               <!-- Run / Instance button -->
               {% if method_json.get('instance') and method_json.instance.get('url') %}
-                <a href="{{ method_json.instance.url }}" class="btn btn-vhpblue w-100 mb-2" target="_blank">Run the method</a>
+                <a href="{{ method_json.instance.url }}" class="btn btn-vhpblue w-100 mb-2" target="_blank" rel="noopener">Run the method</a>
               {% elif method_details.get('instance') and method_details.instance.get('url') %}
-                <a href="{{ method_details.instance.url }}" class="btn btn-vhpblue w-100 mb-2" target="_blank">Run the method</a>
+                <a href="{{ method_details.instance.url }}" class="btn btn-vhpblue w-100 mb-2" target="_blank" rel="noopener">Run the method</a>
               {% elif method_json.get('catalog_webpage_url') or method_details.get('catalog_webpage_url') %}
-                <a href="{{ method_json.get('catalog_webpage_url') or method_details.get('catalog_webpage_url') }}" class="btn btn-outline-vhpblue w-100 mb-2" target="_blank">Method webpage</a>
+                <a href="{{ method_json.get('catalog_webpage_url') or method_details.get('catalog_webpage_url') }}" class="btn btn-outline-vhpblue w-100 mb-2" target="_blank" rel="noopener">Method webpage</a>
               {% else %}
                 <button class="btn btn-outline-secondary w-100 mb-2" disabled>No instance available</button>
               {% endif %}

--- a/templates/methods/method.html
+++ b/templates/methods/method.html
@@ -39,7 +39,7 @@
     {% set description = get('method_description_content', '') or get('method_description', '') or get('description', '—') %}
     
     <div class="pb-2">
-        <h1><span class="text-vhppink" id="collection-name">{{ title }}</span></h1>
+        <h1><span class="text-vhpblue" id="collection-name">{{ title }}</span></h1>
         <p class="text-secondary">{{ description }}</p>
     </div>
     
@@ -47,15 +47,15 @@
   <div class="card-header">
     <ul class="nav nav-tabs card-header-tabs" role="tablist">
       <li class="nav-item" role="presentation">
-        <a class="nav-link text-vhppink active" id="simple-tab-0" data-bs-toggle="tab" href="#simple-tabpanel-0" role="tab" aria-controls="simple-tabpanel-0" aria-selected="true">Overview</a>
+        <a class="nav-link text-vhpblue active" id="simple-tab-0" data-bs-toggle="tab" href="#simple-tabpanel-0" role="tab" aria-controls="simple-tabpanel-0" aria-selected="true">Overview</a>
       </li>
       <li class="nav-item" role="presentation">
-        <a class="nav-link text-vhppink" id="simple-tab-5" data-bs-toggle="tab" href="#simple-tabpanel-5" role="tab" aria-controls="simple-tabpanel-5" aria-selected="false">Publications</a>
+        <a class="nav-link text-vhpblue" id="simple-tab-5" data-bs-toggle="tab" href="#simple-tabpanel-5" role="tab" aria-controls="simple-tabpanel-5" aria-selected="false">Publications</a>
       </li>
       {% set ontology_iri_nav = (method_json.get('ontology_term_content') or method_details.get('ontology_term_content') or '') %}
       {% if ontology_iri_nav and ontology_iri_nav.startswith('http') %}
       <li class="nav-item" role="presentation">
-        <a class="nav-link text-vhppink" id="simple-tab-6" data-bs-toggle="tab" href="#simple-tabpanel-6" role="tab" aria-controls="simple-tabpanel-6" aria-selected="false">Ontology</a>
+        <a class="nav-link text-vhpblue" id="simple-tab-6" data-bs-toggle="tab" href="#simple-tabpanel-6" role="tab" aria-controls="simple-tabpanel-6" aria-selected="false">Ontology</a>
       </li>
       {% endif %}
     </ul>
@@ -113,7 +113,7 @@
             {% set stage = get('vhp4safety_workflow_stage_content', '') or get('vhp4safety_workflow_stage', '—') %}
             {% set substage = get('workflow_substage_content', '') %}
             <p>
-              <span class="badge bg-secondary me-2">{{ stage or '—' }}</span>
+              <span class="badge bg-vhppurple me-2">{{ stage or '—' }}</span>
               {% if substage %}<small class="text-muted">{{ substage }}</small>{% endif %}
             </p>
 
@@ -130,11 +130,11 @@
             <div class="mt-3">
               <!-- Run / Instance button -->
               {% if method_json.get('instance') and method_json.instance.get('url') %}
-                <a href="{{ method_json.instance.url }}" class="btn btn-vhppink w-100 mb-2" target="_blank">Run the method</a>
+                <a href="{{ method_json.instance.url }}" class="btn btn-vhpblue w-100 mb-2" target="_blank">Run the method</a>
               {% elif method_details.get('instance') and method_details.instance.get('url') %}
-                <a href="{{ method_details.instance.url }}" class="btn btn-vhppink w-100 mb-2" target="_blank">Run the method</a>
+                <a href="{{ method_details.instance.url }}" class="btn btn-vhpblue w-100 mb-2" target="_blank">Run the method</a>
               {% elif method_json.get('catalog_webpage_url') or method_details.get('catalog_webpage_url') %}
-                <a href="{{ method_json.get('catalog_webpage_url') or method_details.get('catalog_webpage_url') }}" class="btn btn-outline-vhppink w-100 mb-2" target="_blank">Method webpage</a>
+                <a href="{{ method_json.get('catalog_webpage_url') or method_details.get('catalog_webpage_url') }}" class="btn btn-outline-vhpblue w-100 mb-2" target="_blank">Method webpage</a>
               {% else %}
                 <button class="btn btn-outline-secondary w-100 mb-2" disabled>No instance available</button>
               {% endif %}

--- a/templates/methods/methods.html
+++ b/templates/methods/methods.html
@@ -13,9 +13,9 @@
 <section class="container py-md-5 py-3">
     <!-- Page Title and Description -->
     <div class="">
-        <h1><span class="text-vhppink" id="collection-name">Methods</span></h1>
+        <h1><span class="text-vhpblue" id="collection-name">Methods</span></h1>
         <p class="text-secondary fs-5"> Explore methods developed by and/or used in VHP4Safety. </p>
-        <p>You can search for a method that you know using the search box below. Alternatively, you can filter the methods with respect to the <a class="link-vhppink text-decoration-none" href="{{ url_for('workflows') }}#about-section">case studies' flow step</a> that they belong to and/or the regulatory question that they are associated with. Use the "Filters" button to show filter options, then "Apply Filter" to see results, and click "Clear Filter" to reset the filters.</p>
+        <p>You can search for a method that you know using the search box below. Alternatively, you can filter the methods with respect to the <a class="link-vhpblue text-decoration-none" href="{{ url_for('workflows') }}#about-section">case studies' flow step</a> that they belong to and/or the regulatory question that they are associated with. Use the "Filters" button to show filter options, then "Apply Filter" to see results, and click "Clear Filter" to reset the filters.</p>
 
     </div>
 
@@ -26,7 +26,7 @@
             <input type="hidden" name="stage" id="filter_stage" value="{{ request.args.get('stage', '') }}" />
             <input type="hidden" name="reg_q" id="filter_reg_q" value="{{ request.args.get('reg_q', '') }}" />
             <div class="btn-group" role="group" aria-label="Search and filter buttons">
-                <button type="submit" class="btn btn-outline-vhppink">Search</button>
+                <button type="submit" class="btn btn-outline-vhpblue">Search</button>
                 <a href="{{ url_for('methods') }}" class="btn btn-outline-danger text-nowrap">Clear</a>
                 <button type="button" id="filter-toggle-btn" class="btn btn-outline-secondary">Filters</button>
             </div>
@@ -68,7 +68,7 @@
                     <ul class="dropdown-menu">
                         {% for stage in stages %}
                         <li><a class="dropdown-item " href="#" data-filter-type="flow-step" data-filter-value="{{ stage }}"{% if stage in stage_explanations %} data-bs-toggle="methodtip" data-bs-placement="right" data-bs-title="{{ stage_explanations[stage] }}"{% endif %}>
-                            {{ stage }}{% if stage in stage_explanations %} <i class="text-vhppink bi bi-question-circle"></i>{% endif %}
+                            {{ stage }}{% if stage in stage_explanations %} <i class="text-vhpblue bi bi-question-circle"></i>{% endif %}
                         </a></li>
                         {% endfor %}
                     </ul>
@@ -82,7 +82,7 @@
                     <ul class="dropdown-menu">
                         {% for question in reg_questions.keys() %}
                         <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="{{ question }}"{% if question in reg_question_explanations %} data-bs-toggle="methodtip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations[question] }}"{% endif %}>
-                            {{ question }}{% if question in reg_question_explanations %} <i class="text-vhppink bi bi-question-circle"></i>{% endif %}
+                            {{ question }}{% if question in reg_question_explanations %} <i class="text-vhpblue bi bi-question-circle"></i>{% endif %}
                         </a></li>
                         {% endfor %}
                     </ul>
@@ -100,7 +100,7 @@
             </div>
             
             <div class="">
-                <button id="apply-filter-btn" class="btn btn-sm btn-vhppink mt-2">Apply</button>
+                <button id="apply-filter-btn" class="btn btn-sm btn-vhpblue mt-2">Apply</button>
                 <button id="clear-filter-btn" class="btn btn-sm btn-outline-danger mt-2">Clear</button>
             </div>
         </div>
@@ -125,7 +125,7 @@
                         <div class="btn-group d-flex" role="group" aria-label="Method example">
 
                              <!-- Catalog Page -->
-                            <a href="{{ url_for('methods') }}/{{ item.id }}"  class="btn btn-vhppink flex-grow-1"  data-bs-toggle="methodtip" data-bs-title="View method details"><i class="bi bi-info-circle"></i></a>
+                            <a href="{{ url_for('methods') }}/{{ item.id }}"  class="btn btn-vhpblue flex-grow-1"  data-bs-toggle="methodtip" data-bs-title="View method details"><i class="bi bi-info-circle"></i></a>
                  
 
                             <!-- Method Webpage -->
@@ -169,7 +169,7 @@
                 'flow-step': 'Flow Step',
                 'reg-question': 'Reg. Q'
             },
-            badgeClass: 'badge rounded-pill text-bg-vhppink',
+            badgeClass: 'badge rounded-pill text-bg-vhpblue',
             tooltipSelector: '[data-bs-toggle="methodtip"]',
             showFilterPanel: {% if selected_stages or selected_questions %}true{% else %}false{% endif %}
         });

--- a/templates/tools/tool.html
+++ b/templates/tools/tool.html
@@ -25,7 +25,7 @@
 
 <section class="container py-5">
     <div class="pb-2">
-        <h1><span class="text-vhppink" id="collection-name">{{ tool_json.service }}</span></h1>
+        <h1><span class="text-vhpblue" id="collection-name">{{ tool_json.service }}</span></h1>
 
     </div>
     
@@ -33,13 +33,13 @@
   <div class="card-header">
     <ul class="nav nav-tabs card-header-tabs" role="tablist">
       <li class="nav-item" role="presentation">
-        <a class="nav-link text-vhppink active" id="simple-tab-0" data-bs-toggle="tab" href="#simple-tabpanel-0" role="tab" aria-controls="simple-tabpanel-0" aria-selected="true">Overview</a>
+        <a class="nav-link text-vhpblue active" id="simple-tab-0" data-bs-toggle="tab" href="#simple-tabpanel-0" role="tab" aria-controls="simple-tabpanel-0" aria-selected="true">Overview</a>
       </li>
       <li class="nav-item" role="presentation">
-        <a class="nav-link text-vhppink" id="simple-tab-2" data-bs-toggle="tab" href="#simple-tabpanel-1" role="tab" aria-controls="simple-tabpanel-2" aria-selected="false">Documentation</a>
+        <a class="nav-link text-vhpblue" id="simple-tab-2" data-bs-toggle="tab" href="#simple-tabpanel-1" role="tab" aria-controls="simple-tabpanel-2" aria-selected="false">Documentation</a>
       </li>
       <li class="nav-item" role="presentation">
-        <a class="nav-link text-vhppink" id="simple-tab-3" data-bs-toggle="tab" href="#simple-tabpanel-2" role="tab" aria-controls="simple-tabpanel-3" aria-selected="false">Support</a>
+        <a class="nav-link text-vhpblue" id="simple-tab-3" data-bs-toggle="tab" href="#simple-tabpanel-2" role="tab" aria-controls="simple-tabpanel-3" aria-selected="false">Support</a>
       </li>
     </ul>
   </div>
@@ -137,12 +137,12 @@
         {% if tool_details.instance %}
           {% if tool_details.instance.url %}
           <div style="margin-top: 5px">
-            <a type="button" href="{{ tool_details.instance.url }}" class="btn btn-vhppink flex-grow-1" target="_blank" data-bs-toggle="tooltip" data-bs-title="Try VHP-hosted instance">Run the tool</a>
+            <a type="button" href="{{ tool_details.instance.url }}" class="btn btn-vhpblue flex-grow-1" target="_blank" data-bs-toggle="tooltip" data-bs-title="Try VHP-hosted instance">Run the tool</a>
           </div>
           {% endif %}
         {% elif tool_details.url %}
           <div style="margin-top: 5px">
-            <a type="button" href="{{ tool_details.url}}" class="btn btn-outline-vhppink flex-grow-1" data-bs-toggle="tooltip" data-bs-title="Try non-VHP instance">Run the tool</a>
+            <a type="button" href="{{ tool_details.url}}" class="btn btn-outline-vhpblue flex-grow-1" data-bs-toggle="tooltip" data-bs-title="Try non-VHP instance">Run the tool</a>
           </div>
         {% endif %}
       </div>

--- a/templates/tools/tool.html
+++ b/templates/tools/tool.html
@@ -137,7 +137,7 @@
         {% if tool_details.instance %}
           {% if tool_details.instance.url %}
           <div style="margin-top: 5px">
-            <a type="button" href="{{ tool_details.instance.url }}" class="btn btn-vhpblue flex-grow-1" target="_blank" data-bs-toggle="tooltip" data-bs-title="Try VHP-hosted instance">Run the tool</a>
+            <a type="button" href="{{ tool_details.instance.url }}" class="btn btn-vhpblue flex-grow-1" target="_blank" rel="noopener" data-bs-toggle="tooltip" data-bs-title="Try VHP-hosted instance">Run the tool</a>
           </div>
           {% endif %}
         {% elif tool_details.url %}

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -150,9 +150,9 @@
 
                              <!-- Go to tool -->
                             {% if item.inst_url != "no_url" %}
-                                <a type="button" href="{{ item.inst_url }}" class="btn btn-vhpblue flex-grow-1" target="_blank" data-bs-toggle="tooltip" data-bs-title="Go to tool">Go to tool</a>
+                                <a type="button" href="{{ item.inst_url }}" class="btn btn-vhpblue flex-grow-1" target="_blank" rel="noopener" data-bs-toggle="tooltip" data-bs-title="Go to tool">Go to tool</a>
                             {% elif item.main_url != "no_url" %}
-                                <a type="button" href="{{ item.main_url }}" class="btn btn-vhpblue flex-grow-1" target="_blank" data-bs-toggle="tooltip" data-bs-title="Go to tool">Go to tool</a>
+                                <a type="button" href="{{ item.main_url }}" class="btn btn-vhpblue flex-grow-1" target="_blank" rel="noopener" data-bs-toggle="tooltip" data-bs-title="Go to tool">Go to tool</a>
                             {% else %}
                                 <a type="button" class="btn btn-outline-vhpblue disabled flex-grow-1" data-bs-toggle="tooltip" data-bs-title="No webpage available">Go to tool</a>
                             {% endif %}

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -11,12 +11,12 @@
 <section class="container py-md-5 py-3">
     <!-- Page Title and Description -->
     <div class="">
-        <h1><span class="text-vhppink" id="collection-name">Tools</span></h1>
+        <h1><span class="text-vhpblue" id="collection-name">Tools</span></h1>
         <p class="text-secondary fs-5"> Explore tools developed by and/or used in VHP4Safety. </p>
-        <p>You can search for a tool that you know using the search box below. Alternatively, you can filter the tools with respect to the <a class="link-vhppink text-decoration-none" href="{{ url_for('workflows') }}#about-section">case studies' flow step</a> that they belong to and/or the regulatory question that they are associated with. Use the "Filters" button to show filter options, then "Apply Filter" to see results, and click "Clear Filter" to reset the filters.</p>
+        <p>You can search for a tool that you know using the search box below. Alternatively, you can filter the tools with respect to the <a class="link-vhpblue text-decoration-none" href="{{ url_for('workflows') }}#about-section">case studies' flow step</a> that they belong to and/or the regulatory question that they are associated with. Use the "Filters" button to show filter options, then "Apply Filter" to see results, and click "Clear Filter" to reset the filters.</p>
 
         <p class="text-secondary fs-5"> Contribution and Feedback </p>
-        <p>We welcome and appreciate any feedback on this catalog of tools or the individual tools listed in it. We also appreciate receiving requests for other tools that you are aware of and deem relevant to this catalog. For these contribution and feedback, please feel free to create <a class="link-vhppink text-decoration-none" href="https://github.com/VHP4Safety/virtual-human-platform/issues">an issue at our repository</a>.
+        <p>We welcome and appreciate any feedback on this catalog of tools or the individual tools listed in it. We also appreciate receiving requests for other tools that you are aware of and deem relevant to this catalog. For these contribution and feedback, please feel free to create <a class="link-vhpblue text-decoration-none" href="https://github.com/VHP4Safety/virtual-human-platform/issues">an issue at our repository</a>.
     </div>
 
     <nav class="navbar navbar-expand-lg bg-body-tertiary mb-3 d-inline">
@@ -26,7 +26,7 @@
             <input type="hidden" name="stage" id="filter_stage" value="{{ request.args.get('stage', '') }}" />
             <input type="hidden" name="reg_q" id="filter_reg_q" value="{{ request.args.get('reg_q', '') }}" />
             <div class="btn-group" role="group" aria-label="Search and filter buttons">
-                <button type="submit" class="btn btn-outline-vhppink">Search</button>
+                <button type="submit" class="btn btn-outline-vhpblue">Search</button>
                 <a href="{{ url_for('tools') }}" class="btn btn-outline-danger text-nowrap">Clear</a>
                 <button type="button" id="filter-toggle-btn" class="btn btn-outline-secondary">Filters</button>
             </div>
@@ -68,7 +68,7 @@
                     <ul class="dropdown-menu">
                         {% for stage in stages %}
                         <li><a class="dropdown-item " href="#" data-filter-type="flow-step" data-filter-value="{{ stage }}"{% if stage in stage_explanations %} data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations[stage] }}"{% endif %}>
-                            {{ stage }}{% if stage in stage_explanations %} <i class="text-vhppink bi bi-question-circle"></i>{% endif %}
+                            {{ stage }}{% if stage in stage_explanations %} <i class="text-vhpblue bi bi-question-circle"></i>{% endif %}
                         </a></li>
                         {% endfor %}
                     </ul>
@@ -82,7 +82,7 @@
                     <ul class="dropdown-menu">
                         {% for question in reg_questions.keys() %}
                         <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="{{ question }}"{% if question in reg_question_explanations %} data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations[question] }}"{% endif %}>
-                            {{ question }}{% if question in reg_question_explanations %} <i class="text-vhppink bi bi-question-circle"></i>{% endif %}
+                            {{ question }}{% if question in reg_question_explanations %} <i class="text-vhpblue bi bi-question-circle"></i>{% endif %}
                         </a></li>
                         {% endfor %}
                     </ul>
@@ -100,7 +100,7 @@
             </div>
             
             <div class="">
-                <button id="apply-filter-btn" class="btn btn-sm btn-vhppink mt-2">Apply</button>
+                <button id="apply-filter-btn" class="btn btn-sm btn-vhpblue mt-2">Apply</button>
                 <button id="clear-filter-btn" class="btn btn-sm btn-outline-danger mt-2">Clear</button>
             </div>
         </div>
@@ -150,11 +150,11 @@
 
                              <!-- Go to tool -->
                             {% if item.inst_url != "no_url" %}
-                                <a type="button" href="{{ item.inst_url }}" class="btn btn-vhppink flex-grow-1" target="_blank" data-bs-toggle="tooltip" data-bs-title="Go to tool">Go to tool</a>
+                                <a type="button" href="{{ item.inst_url }}" class="btn btn-vhpblue flex-grow-1" target="_blank" data-bs-toggle="tooltip" data-bs-title="Go to tool">Go to tool</a>
                             {% elif item.main_url != "no_url" %}
-                                <a type="button" href="{{ item.main_url }}" class="btn btn-vhppink flex-grow-1" target="_blank" data-bs-toggle="tooltip" data-bs-title="Go to tool">Go to tool</a>
+                                <a type="button" href="{{ item.main_url }}" class="btn btn-vhpblue flex-grow-1" target="_blank" data-bs-toggle="tooltip" data-bs-title="Go to tool">Go to tool</a>
                             {% else %}
-                                <a type="button" class="btn btn-outline-vhppink disabled flex-grow-1" data-bs-toggle="tooltip" data-bs-title="No webpage available">Go to tool</a>
+                                <a type="button" class="btn btn-outline-vhpblue disabled flex-grow-1" data-bs-toggle="tooltip" data-bs-title="No webpage available">Go to tool</a>
                             {% endif %}
 
                             <!-- Meta-Data -->


### PR DESCRIPTION
Make the colours we decided on for the case study page leading (see issue #176 unsure where shaki put results of said meeting). I remember we made these decisions with Fabian, Shakira and Ozan back in January. These decisions have been implemented on the case study page but are not consistently implemented across the platfom.

Core principle: allignment with case studies nav bar with the rest of the platform

<img style="aling-items-center" width="1582" height="292" alt="image" src="https://github.com/user-attachments/assets/a8c24be1-130b-4798-b265-d0f9ac45c044" />


- Make methods, tools and data all blue. I don’t think we need additional colour coding for these elements as are self explanatory. The home page will look less appealing but i think systematic/consistency beats fun. 
- Make the workflow steps purple
- Regulatory question and case study are both pink. This make sense as they are related/dependend on eachother 
- Anything between flowstep and tools will be either dark teal or teal, or some other green 

- Updated text and background colors in data_details.html, home.html, method.html, methods.html, tool.html, and tools.html to replace instances of 'text-vhppink' and 'bg-vhppink' with 'text-vhpblue' and 'bg-vhpblue'.
- Adjusted button styles and links to align with the new color scheme.
- Ensured that all relevant sections reflect the updated color choices for a cohesive user experience.


<table>
  <tr>
    <td><img width="2940" height="1654" alt="image" src="https://github.com/user-attachments/assets/c3184240-238f-4483-b319-7c4bead7d694" />
</td>
    <td><img width="2940" height="1638" alt="image" src="https://github.com/user-attachments/assets/5bd96fef-7370-4554-b4bf-9482dec0306d" />
</td>
  </tr>
<tr>
<td>
<img width="2940" height="1626" alt="image" src="https://github.com/user-attachments/assets/69f7f373-9609-42ab-8cb6-0d1697c55f2e" />
</td>
<td><img width="2940" height="1612" alt="image" src="https://github.com/user-attachments/assets/5188c193-c3f5-4f01-a851-3f6556cb2bb6" />
</td>
</tr>
<tr>
<td>
<img width="2940" height="1344" alt="image" src="https://github.com/user-attachments/assets/cd9a1afa-faa4-4685-bd43-6d08b590bf90" />
</td>
<td><img width="2940" height="1342" alt="image" src="https://github.com/user-attachments/assets/dd3bd852-bf40-4d5a-a64d-6d3150c394a3" />
</td>
</tr>
</table>