### PR TITLE
feat(ui): set container max-width to 900px for larger breakpoints for better readability

### DIFF
--- a/bootstrap-custom/custom.scss
+++ b/bootstrap-custom/custom.scss
@@ -70,10 +70,22 @@ $theme-colors-text-dark: map-merge($theme-colors-text-dark, $custom-text-emphasi
 $theme-colors-bg-subtle-dark: map-merge($theme-colors-bg-subtle-dark, $custom-bg-subtle-dark);
 $theme-colors-border-subtle-dark: map-merge($theme-colors-border-subtle-dark, $custom-border-subtle-dark);
 
+// Cap .container max-width at 900px from the lg breakpoint up. Below lg, keep
+// Bootstrap's defaults so the container still fits smaller viewports. Replaces
+// the `.container { max-width: 900px !important }` rule that used to live in
+// static/css/base.css -- now driven by the SCSS map, no !important hack.
+$container-max-widths: (
+  sm: 540px,
+  md: 720px,
+  lg: 900px,
+  xl: 900px,
+  xxl: 900px,
+);
+
 // 4️⃣ Override Bootstrap link defaults BEFORE importing Bootstrap
 $link-color: $black;                      // Default link color
 $link-hover-color: map-get($theme-colors, "vhpblue");  // Hover color to your blue
-$link-decoration: none; 
+$link-decoration: none;
 
 // 5️⃣ Import the rest of Bootstrap (it now uses your colors)
 @import "bootstrap/scss/bootstrap";

--- a/static/css/bootstrap-custom.css
+++ b/static/css/bootstrap-custom.css
@@ -864,17 +864,17 @@ progress {
 }
 @media (min-width: 992px) {
   .container-lg, .container-md, .container-sm, .container {
-    max-width: 960px;
+    max-width: 900px;
   }
 }
 @media (min-width: 1200px) {
   .container-xl, .container-lg, .container-md, .container-sm, .container {
-    max-width: 1140px;
+    max-width: 900px;
   }
 }
 @media (min-width: 1400px) {
   .container-xxl, .container-xl, .container-lg, .container-md, .container-sm, .container {
-    max-width: 1320px;
+    max-width: 900px;
   }
 }
 :root {


### PR DESCRIPTION
Addresses #409 

<table><tr><td>Before</td><td>After</td></tr>
<tr>
<td>
<img width="1469" height="729" alt="Screenshot 2026-05-16 at 16 15 21" src="https://github.com/user-attachments/assets/8ed9769e-1df4-4d3d-b156-530d5961cf22" /></td>
<td>
<img width="1467" height="830" alt="Screenshot 2026-05-16 at 16 15 00" src="https://github.com/user-attachments/assets/cb370a25-6e50-4af0-a8a4-b81c4208cd19" /></td>
</tr>
</table>