### PR TITLE
Update Filter Section in Tools, Methods and Data

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ from jinja2 import TemplateNotFound
 from werkzeug.routing import BaseConverter
 
 # from wikidataintegrator import wdi_core
-from wikibaseintegrator import wbi_helpers
+# from wikibaseintegrator import wbi_helpers
 
 # Import BioStudies extractor
 from data.biostudies.search import BioStudiesExtractor
@@ -27,8 +27,6 @@ BIOSTUDIES_COLLECTION = "VHP4Safety"  # Replace with "EU-ToxRisk" to test
 BIOSTUDIES_COLLECTION_NAME = "VHP4Safety"  # Display name for the page
 ZENODO_COMMUNITY = "vhp4safety"  # zenodo community
 ZENODO_RECORD_TYPE = "dataset"  # only show datasets
-
-CASESTUDIES = ["thyroid", "kidney", "parkinson"]  # List of valid case studies
 
 # Non-glossary "stage" labels. The five Process Flow Step stages are resolved
 # from the VHP glossary at runtime (see get_process_flow_steps); these legacy
@@ -58,39 +56,10 @@ SERVICES_URL = "https://raw.githubusercontent.com/VHP4Safety/cloud/refs/heads/ma
 GLOSSARY_URL = (
     "https://raw.githubusercontent.com/VHP4Safety/glossary/refs/heads/main/glossary.owl"
 )
-
-REG_QUESTIONS = {
-    "reg_q_1a": {
-        "label": "Kidney Case Study (a)",
-        "explanation": "What is the safe cisplatin dose in cancer patients?",
-    },
-    "reg_q_1b": {
-        "label": "Kidney Case Study (b)",
-        "explanation": "What is the intrinsic hazard of tacrolimus for nephrotoxicity?",
-    },
-    "reg_q_2a": {
-        "label": "Parkinson Case Study (a)",
-        "explanation": "Can compound Dinoseb cause Parkinson's Disease?",
-    },
-    "reg_q_2b": {
-        "label": "Parkinson Case Study (b)",
-        "explanation": "What level of exposure to compound Dinoseb leads to risk for developing Parkinson’s disease?",
-    },
-    "reg_q_3a": {
-        "label": "Thyroid Case Study (a)",
-        "explanation": "What information about silychristin do we need to give an advice to women in their early pregnancy to decide whether the substance can be used?",
-    },
-    "reg_q_3b": {
-        "label": "Thyroid Case Study (b)",
-        "explanation": "Does silychristin influence the thyroid-mediated brain development in the fetus resulting in cognitive impairment in children?",
-    },
-}
-
-# Derived: keep the old structure available for templates expecting {label: explanation}
-REG_QUESTION_EXPLANATIONS = {
-    v["label"]: v["explanation"] for v in REG_QUESTIONS.values()
-}
-
+CASESTUDIES_URL = (
+    "https://raw.githubusercontent.com/VHP4Safety/ui-casestudy-config/"
+    "refs/heads/main/casestudies.jsonld"
+)
 
 ################################################################################
 class RegexConverter(BaseConverter):
@@ -169,6 +138,96 @@ def get_service_detail(tool_id: str, timeout: int = 5) -> dict:
         return _get_service_detail_cached(tool_id, timeout=timeout)
     except Exception:
         return {}
+
+
+# --- Case studies & regulatory questions -----------------------------------
+# (case slug, question index) -> reg_q_Xy upstream field name. This is the
+# only remaining hardcoded artifact: the keys must match upstream tool/method
+# index field names (used to filter records) and the casestudy config files
+# do not currently record them. If a field like `upstreamField` were added to
+# each question in <case>_content.json's step1Contents.questions[], this map
+# could be derived from the config too.
+_REG_QUESTION_KEYS = {
+    ("kidney", 0): "reg_q_1a",
+    ("kidney", 1): "reg_q_1b",
+    ("parkinson", 0): "reg_q_2a",
+    ("parkinson", 1): "reg_q_2b",
+    ("thyroid", 0): "reg_q_3a",
+    ("thyroid", 1): "reg_q_3b",
+}
+
+
+@cache.memoize(timeout=CACHE_TIMEOUT)
+def get_casestudies() -> dict:
+    """Return case studies from VHP4Safety/ui-casestudy-config's JSON-LD index.
+
+    Returns {slug: {"name", "description", "content_url"}}. Iteration yields
+    slugs, so callers that just need the slug list can do `for c in
+    get_casestudies()`. Returns an empty dict on any error so callers degrade
+    safely.
+    """
+    try:
+        resp = requests.get(CASESTUDIES_URL, timeout=5)
+        if resp.status_code != 200:
+            return {}
+        data = resp.json()
+    except Exception:
+        return {}
+
+    studies = {}
+    for entry in data.get("dataset", []):
+        slug = entry.get("slug")
+        if not slug:
+            continue
+        studies[slug] = {
+            "name": entry.get("name", ""),
+            "description": entry.get("description", ""),
+            "content_url": (entry.get("distribution") or {}).get("contentUrl", ""),
+        }
+    return studies
+
+
+@cache.memoize(timeout=CACHE_TIMEOUT)
+def get_casestudy_content(slug: str) -> dict:
+    """Fetch the per-case `<slug>_content.json` from the config repo."""
+    url = get_casestudies().get(slug, {}).get("content_url")
+    if not url:
+        return {}
+    try:
+        resp = requests.get(url, timeout=5)
+        if resp.status_code != 200:
+            return {}
+        return resp.json() or {}
+    except Exception:
+        return {}
+
+
+def get_reg_questions() -> dict:
+    """Build {reg_q_Xy: {"label", "explanation"}} from per-case content JSONs.
+
+    Keys come from _REG_QUESTION_KEYS (upstream field names). Labels and
+    explanations come from each case's step1Contents.questions[] entries in
+    the remote casestudy config (label and description fields respectively).
+    """
+    result = {}
+    for slug in get_casestudies():
+        content = get_casestudy_content(slug)
+        questions = (content.get("step1Contents") or {}).get("questions") or []
+        for i, q in enumerate(questions[:2]):
+            key = _REG_QUESTION_KEYS.get((slug, i))
+            if not key:
+                continue
+            result[key] = {
+                "label": q.get("label") or f"{slug.title()} Q{i + 1}",
+                "explanation": q.get("description", ""),
+                "case": slug,
+            }
+    return result
+
+
+def get_reg_question_explanations() -> dict:
+    """{label: explanation} for templates that look up by hardcoded label."""
+    return {v["label"]: v["explanation"] for v in get_reg_questions().values()}
 
 
 # Suffix the VHP glossary uses to mark an owl:Class as a Process Flow Step stage.
@@ -461,7 +520,7 @@ def home():
     except Exception as e:
         return f"Error processing service data: {e}", 500
     num_tools = len(tools)
-    num_case_studies = len(CASESTUDIES)
+    num_case_studies = len(get_casestudies())
     bs_res, zen_res = get_repository_data(search_query="")
     num_datasets = bs_res.get("total", 0) + zen_res.get("total", 0)
     return render_template(
@@ -551,7 +610,7 @@ def sitemap():
         pass
 
     # Case study detail pages
-    paths += [f"/casestudies/{urllib.parse.quote(c)}" for c in CASESTUDIES]
+    paths += [f"/casestudies/{urllib.parse.quote(c)}" for c in get_casestudies()]
 
     # Dedupe while preserving order
     seen = set()
@@ -664,7 +723,10 @@ def data():
         pages_fetched=pages_fetched,
         page_size_met=page_size_met,
         stage_explanations=get_stage_explanations(),
-        reg_question_explanations=REG_QUESTION_EXPLANATIONS,
+        reg_question_explanations=get_reg_question_explanations(),
+        reg_question_cases={v["label"]: v.get("case", "") for v in get_reg_questions().values()},
+        reg_questions={v["label"]: k for k, v in get_reg_questions().items()},
+        case_studies=list(get_casestudies()),
     )
 
 
@@ -794,7 +856,10 @@ def models():
         pages_fetched=pages_fetched,
         page_size_met=page_size_met,
         stage_explanations=get_stage_explanations(),
-        reg_question_explanations=REG_QUESTION_EXPLANATIONS,
+        reg_question_explanations=get_reg_question_explanations(),
+        reg_question_cases={v["label"]: v.get("case", "") for v in get_reg_questions().values()},
+        reg_questions={v["label"]: k for k, v in get_reg_questions().items()},
+        case_studies=list(get_casestudies()),
     )
 
 
@@ -841,7 +906,7 @@ def tools():
             stages.append("Other")
 
         # Filtering over the regulatory questions.
-        reg_questions = {v["label"]: k for k, v in REG_QUESTIONS.items()}
+        reg_questions = {v["label"]: k for k, v in get_reg_questions().items()}
 
         selected_questions = request.args.getlist("reg_q")
 
@@ -925,7 +990,8 @@ def tools():
             reg_questions=reg_questions,
             selected_questions=selected_questions,
             stage_explanations=get_stage_explanations(),
-            reg_question_explanations=REG_QUESTION_EXPLANATIONS,
+            reg_question_explanations=get_reg_question_explanations(),
+        reg_question_cases={v["label"]: v.get("case", "") for v in get_reg_questions().values()},
             page=page,
             page_size=page_size,
             total=total,
@@ -1009,8 +1075,8 @@ def methods():
                 )
             ]
 
-        # Filter by regulatory questions if provided (REG_QUESTIONS keys map to internal fields)
-        reg_questions = {v["label"]: k for k, v in REG_QUESTIONS.items()}
+        # Filter by regulatory questions if provided (reg_q_Xy keys are upstream field names)
+        reg_questions = {v["label"]: k for k, v in get_reg_questions().items()}
         if selected_questions:
             for question in selected_questions:
                 field = reg_questions.get(question)
@@ -1052,7 +1118,8 @@ def methods():
             reg_questions=reg_questions,
             selected_questions=selected_questions,
             stage_explanations=get_stage_explanations(),
-            reg_question_explanations=REG_QUESTION_EXPLANATIONS,
+            reg_question_explanations=get_reg_question_explanations(),
+        reg_question_cases={v["label"]: v.get("case", "") for v in get_reg_questions().values()},
             page=page,
             page_size=page_size,
             total=total,
@@ -1193,7 +1260,7 @@ def workflows():
 @app.route("/casestudies/<case>/<question>/<step>")
 # additional routes are parsed client side via js to allow smooth animation
 def casestudy(case: str = "", question: str = "", step: str = ""):
-    if case not in CASESTUDIES:
+    if case not in get_casestudies():
         abort(404)
     # JS will handle steps via the URL
     return render_template("case_studies/casestudy.html", case=case)

--- a/app.py
+++ b/app.py
@@ -650,21 +650,22 @@ def data():
     page_size = request.args.get("page_size", 6, type=int)
     search_query = request.args.get("query", "", type=str)
 
-    # Get filter parameters
-    filter_case_study = request.args.get("filter_case_study", "", type=str)
-    filter_regulatory_question = request.args.get(
-        "filter_regulatory_question", "", type=str
-    )
-    filter_flow_step = request.args.get("filter_flow_step", "", type=str)
+    # Get filter parameters (multi-select via repeated query params, matching
+    # tools/methods). Each filter type is a list; the extractor groups by
+    # field and applies OR-within-field, AND-across-fields.
+    filter_case_study = request.args.getlist("filter_case_study")
+    filter_regulatory_question = request.args.getlist("filter_regulatory_question")
+    filter_flow_step = request.args.getlist("filter_flow_step")
 
-    # Build filter list (only include non-empty filters)
+    # Build filter list (one tuple per (field, value)); repeated field names
+    # become OR within that field downstream in _apply_filters.
     filters = []
-    if filter_case_study:
-        filters.append(("case_study", filter_case_study))
-    if filter_regulatory_question:
-        filters.append(("regulatory_question", filter_regulatory_question))
-    if filter_flow_step:
-        filters.append(("flow_step", filter_flow_step))
+    for v in filter_case_study:
+        filters.append(("case_study", v))
+    for v in filter_regulatory_question:
+        filters.append(("regulatory_question", v))
+    for v in filter_flow_step:
+        filters.append(("flow_step", v))
 
     # Split page budget between the two repositories so the combined output
     # respects page_size (e.g. page_size=6 -> 3 from each source).
@@ -907,6 +908,25 @@ def tools():
         if selected_stages:
             tools = [tool for tool in tools if tool.get("stage") in selected_stages]
 
+        # Filter by case study. Tools have no `case_study` field; membership
+        # is derived from the reg_q_Xy booleans via _REG_QUESTION_KEYS
+        # (e.g. selecting "Kidney" matches tools where reg_q_1a OR reg_q_1b
+        # is "true"). OR within type, AND across types.
+        selected_case_studies = request.args.getlist("case_study")
+        if selected_case_studies:
+            slugs_lc = {c.lower() for c in selected_case_studies}
+            case_fields = [
+                field
+                for (slug, _), field in _REG_QUESTION_KEYS.items()
+                if slug in slugs_lc
+            ]
+            if case_fields:
+                tools = [
+                    tool
+                    for tool in tools
+                    if any(str(tool.get(f, "")).lower() == "true" for f in case_fields)
+                ]
+
         # Filtering over the regulatory questions. OR within type: a tool
         # passes if any of the selected questions' reg_q_Xy field is "true".
         # Matches the convention used by every other within-type filter on
@@ -995,11 +1015,13 @@ def tools():
             tools=tools,
             stages=stages,
             selected_stages=selected_stages,
+            case_studies=list(get_casestudies()),
+            selected_case_studies=selected_case_studies,
             reg_questions=reg_questions,
             selected_questions=selected_questions,
             stage_explanations=get_stage_explanations(),
             reg_question_explanations=get_reg_question_explanations(),
-        reg_question_cases={v["label"]: v.get("case", "") for v in get_reg_questions().values()},
+            reg_question_cases={v["label"]: v.get("case", "") for v in get_reg_questions().values()},
             page=page,
             page_size=page_size,
             total=total,

--- a/app.py
+++ b/app.py
@@ -890,6 +890,16 @@ def tools():
                 # Combining "NA" and "Unknown" stages in a single stage-type, "Other".
                 tool["stage"] = "Other"
 
+        # Collect all unique stages from the UNFILTERED tools first so the
+        # Flow Step dropdown is stable -- otherwise applying a filter shrinks
+        # the dropdown to just the values present in the filtered set, and
+        # removing a filter pill (which doesn't trigger a server reload) can't
+        # restore the missing options. Matches the methods() behaviour.
+        stages = sorted(set(tool.get("stage") for tool in tools if tool.get("stage")))
+        if "Other" in stages:
+            stages.remove("Other")
+            stages.append("Other")
+
         # Getting selected stages from the URL.
         selected_stages = request.args.getlist("stage")
 
@@ -897,25 +907,23 @@ def tools():
         if selected_stages:
             tools = [tool for tool in tools if tool.get("stage") in selected_stages]
 
-        # Getting all unique stages from the tools for the filter options.
-        stages = sorted(set(tool.get("stage") for tool in tools if tool.get("stage")))
-
-        # Forcing "Other" to be the last item in the list of stages.
-        if "Other" in stages:
-            stages.remove("Other")
-            stages.append("Other")
-
-        # Filtering over the regulatory questions.
+        # Filtering over the regulatory questions. OR within type: a tool
+        # passes if any of the selected questions' reg_q_Xy field is "true".
+        # Matches the convention used by every other within-type filter on
+        # the platform (flow-step, case-study, methods reg-question).
         reg_questions = {v["label"]: k for k, v in get_reg_questions().items()}
 
         selected_questions = request.args.getlist("reg_q")
 
-        for question in selected_questions:
-            field = reg_questions.get(question)
-            if field:
-                tools = [
-                    tool for tool in tools if str(tool.get(field, "")).lower() == "true"
-                ]
+        if selected_questions:
+            fields = [
+                reg_questions.get(q) for q in selected_questions if reg_questions.get(q)
+            ]
+            tools = [
+                tool
+                for tool in tools
+                if any(str(tool.get(f, "")).lower() == "true" for f in fields)
+            ]
 
         # Getting the search query from URL to add a search bar based on tool names.
         search_query = request.args.get("search", "").strip().lower()

--- a/app.py
+++ b/app.py
@@ -521,12 +521,18 @@ def home():
         return f"Error processing service data: {e}", 500
     num_tools = len(tools)
     num_case_studies = len(get_casestudies())
+    try:
+        methods = get_json_dict(METHODS_URL)
+        num_methods = len(methods) if isinstance(methods, dict) else 0
+    except Exception:
+        num_methods = 0
     bs_res, zen_res = get_repository_data(search_query="")
     num_datasets = bs_res.get("total", 0) + zen_res.get("total", 0)
     return render_template(
         "home.html",
         num_tools=num_tools,
         num_case_studies=num_case_studies,
+        num_methods=num_methods,
         num_datasets=num_datasets,
         process_flow_steps=get_process_flow_steps(),
         partner_logos=get_partner_logos(),

--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ from jinja2 import TemplateNotFound
 from werkzeug.routing import BaseConverter
 
 # from wikidataintegrator import wdi_core
-# from wikibaseintegrator import wbi_helpers
+from wikibaseintegrator import wbi_helpers
 
 # Import BioStudies extractor
 from data.biostudies.search import BioStudiesExtractor
@@ -1017,7 +1017,15 @@ def methods():
     try:
         methods = list(methods.values())  # convert dict to list
 
-        # Normalize fields for the template and collect stages
+        # Normalize fields for the template and collect stages.
+        # `vhp4safety_workflow_stage_content` is expected to hold glossary URIs
+        # (same convention as service_index.json), e.g.
+        # "https://vhp4safety.github.io/glossary#VHP0000156". We translate the
+        # URI to the human label via get_stage_mapping(), so the dropdown,
+        # filter, and tooltip (driven by get_stage_explanations()) all speak
+        # the same vocabulary. Values that don't match a known URI fall
+        # through as-is so legacy / typo values still render.
+        stage_mapping = get_stage_mapping()
         stages_set = set()
         normalized = []
         for m in methods:
@@ -1044,48 +1052,62 @@ def methods():
             # keep original raw data for potential details page
             norm["raw"] = m
 
-            # collect stages (split comma-separated values)
+            # Collect stages (split comma-separated values). Each part is a
+            # glossary URI -> we resolve it to the human label. Placeholder
+            # strings ("_No response_" / "No response") are skipped. The
+            # resolved labels are stored on the record so the stage filter
+            # below can match against them directly.
             stage_field = (m.get("vhp4safety_workflow_stage_content") or "").strip()
+            resolved_stages = []
             if stage_field:
                 for part in [s.strip() for s in stage_field.split(",")]:
-                    if part:
-                        stages_set.add(part)
+                    if not part or part.lower().strip("_") == "no response":
+                        continue
+                    label = stage_mapping.get(part, part)  # URI -> label, else as-is
+                    resolved_stages.append(label)
+                    stages_set.add(label)
+            norm["stages"] = resolved_stages
 
             normalized.append(norm)
 
         # Apply search and filters similar to /tools
+        selected_case_studies = request.args.getlist("case_study")
         selected_stages = request.args.getlist("stage")
         selected_questions = request.args.getlist("reg_q")
         search_query = request.args.get("search", "").strip().lower()
 
         methods_filtered = normalized
 
+        if selected_case_studies:
+            # UI sends "Thyroid" (slug.title()); records store the lowercase
+            # slug ("thyroid"). Case-insensitive match handles both ends.
+            cs_lower = {c.lower() for c in selected_case_studies}
+            methods_filtered = [
+                m for m in methods_filtered
+                if (m["raw"].get("case_study") or "").strip().lower() in cs_lower
+            ]
+
         if selected_stages:
+            # Match against the URI-resolved labels stored on `norm["stages"]`,
+            # so the filter speaks the same vocabulary as the dropdown.
+            sel = set(selected_stages)
+            methods_filtered = [
+                m for m in methods_filtered if sel & set(m.get("stages") or [])
+            ]
+
+        # Filter by regulatory questions. Methods records carry the canonical
+        # reg_q_Xy key directly in the `regulatory_question` field (e.g.
+        # "reg_q_1b"), matching the tools/data convention.
+        reg_questions = {v["label"]: k for k, v in get_reg_questions().items()}
+        if selected_questions:
+            selected_keys = {
+                reg_questions.get(q) for q in selected_questions if reg_questions.get(q)
+            }
             methods_filtered = [
                 m
                 for m in methods_filtered
-                if any(
-                    s
-                    in (
-                        (m["raw"].get("vhp4safety_workflow_stage_content") or "").split(
-                            ","
-                        )
-                    )
-                    for s in selected_stages
-                )
+                if (m["raw"].get("regulatory_question") or "").strip() in selected_keys
             ]
-
-        # Filter by regulatory questions if provided (reg_q_Xy keys are upstream field names)
-        reg_questions = {v["label"]: k for k, v in get_reg_questions().items()}
-        if selected_questions:
-            for question in selected_questions:
-                field = reg_questions.get(question)
-                if field:
-                    methods_filtered = [
-                        m
-                        for m in methods_filtered
-                        if str(m["raw"].get(field, "")).lower() == "true"
-                    ]
 
         if search_query:
             methods_filtered = [
@@ -1115,11 +1137,13 @@ def methods():
             methods=methods_page,
             stages=stages,
             selected_stages=selected_stages,
+            case_studies=list(get_casestudies()),
+            selected_case_studies=selected_case_studies,
             reg_questions=reg_questions,
             selected_questions=selected_questions,
             stage_explanations=get_stage_explanations(),
             reg_question_explanations=get_reg_question_explanations(),
-        reg_question_cases={v["label"]: v.get("case", "") for v in get_reg_questions().values()},
+            reg_question_cases={v["label"]: v.get("case", "") for v in get_reg_questions().values()},
             page=page,
             page_size=page_size,
             total=total,

--- a/data/biostudies/search.py
+++ b/data/biostudies/search.py
@@ -488,28 +488,32 @@ class BioStudiesExtractor:
 
     def _apply_filters(self, hits: list, filters: list[tuple]) -> list:
         """
-        Filter hits based on metadata field values (case-insensitive AND logic)
+        Filter hits based on metadata field values.
+
+        Semantics: OR within the same field name (e.g. ("case_study","Kidney")
+        and ("case_study","Parkinson") together match records in either case),
+        AND across different field names. Case-insensitive. Matches the
+        convention used by tools/methods filters.
         """
         if not filters:
             return hits
+
+        # Group accepted values by field name, lowercased for case-insensitive
+        # comparison.
+        accepted_by_field: dict[str, list[str]] = {}
+        for field, value in filters:
+            accepted_by_field.setdefault(field, []).append(str(value).strip().lower())
 
         filtered = []
         for hit in hits:
             metadata = hit.get("metadata", {})
             if not metadata:
                 continue
-
-            matches_all = True
-            for field, value in filters:
-                field_value = str(metadata.get(field, "")).strip().lower()
-                filter_value = str(value).strip().lower()
-                if field_value != filter_value:
-                    matches_all = False
-                    break
-
-            if matches_all:
+            if all(
+                str(metadata.get(field, "")).strip().lower() in accepted
+                for field, accepted in accepted_by_field.items()
+            ):
                 filtered.append(hit)
-
         return filtered
 
     def _backfill_filtered_results(

--- a/data/zenodo/search.py
+++ b/data/zenodo/search.py
@@ -314,13 +314,23 @@ class ZenodoExtractor:
     def _apply_filters(
         self, hits: list[dict[str, Any]], filters: tuple[tuple[str, str]] | None
     ) -> list[dict[str, Any]]:
-        """Apply AND-filters to hits using parsed metadata when available.
+        """Apply filters to hits using parsed metadata when available.
 
-        Field matching is case-insensitive. For list fields (keywords, creators,
-        communities) we match if any element contains the filter value.
+        Semantics: OR within the same field name (e.g. multiple case_study
+        values match any of them), AND across different field names. Matches
+        the convention used by tools/methods filters. Field matching is
+        case-insensitive. For list fields (keywords, creators, communities)
+        a record matches a field if ANY of its list elements contains ANY
+        of the accepted values.
         """
         if not filters:
             return hits
+
+        # Group accepted values by field name, lowercased for case-insensitive
+        # comparison.
+        accepted_by_field: dict[str, list[str]] = {}
+        for field, value in filters:
+            accepted_by_field.setdefault(field, []).append(value.lower())
 
         filtered: list[dict[str, Any]] = []
         for hit in hits:
@@ -328,41 +338,34 @@ class ZenodoExtractor:
             if not metadata:
                 continue
 
-            matches_all = True
-            for field, value in filters:
-                filter_value = value.lower()
+            matches_all_fields = True
+            for field, accepted in accepted_by_field.items():
                 field_value = metadata.get(field, "")
 
                 if isinstance(field_value, list):
-                    # normalize list values to strings
                     found = False
                     for item in field_value:
-                        # item may be dict (e.g., creators)
                         if isinstance(item, dict):
-                            # try to match on common text fields
                             text = " ".join(
                                 str(v) for v in item.values() if isinstance(v, str)
-                            )
+                            ).lower()
                         else:
-                            text = str(item)
-                        if filter_value in text.lower():
+                            text = str(item).lower()
+                        if any(v in text for v in accepted):
                             found = True
                             break
                     if not found:
-                        matches_all = False
+                        matches_all_fields = False
                         break
-
                 else:
                     if not isinstance(field_value, str):
                         field_value = str(field_value)
-                    if (
-                        filter_value != field_value.lower()
-                        and filter_value not in field_value.lower()
-                    ):
-                        matches_all = False
+                    fv = field_value.lower()
+                    if not any(v == fv or v in fv for v in accepted):
+                        matches_all_fields = False
                         break
 
-            if matches_all:
+            if matches_all_fields:
                 filtered.append(hit)
 
         return filtered

--- a/static/js/search_filter.js
+++ b/static/js/search_filter.js
@@ -149,17 +149,16 @@
         });
       }
 
-      // Dropdown item clicks
+      // Dropdown item clicks. Let the click bubble so Bootstrap's auto-close
+      // handler fires — the dropdown closes after each selection, and the user
+      // re-opens it to add more. Pills below show what's already selected.
       document.querySelectorAll('.dropdown-item[data-filter-type]').forEach(item => {
         item.addEventListener('click', (e) => {
           e.preventDefault();
-          if (this.config.multiSelect) {
-            e.stopPropagation(); // Keep dropdown open for multi-select
-          }
-          
+
           const filterType = item.dataset.filterType;
           const filterValue = item.dataset.filterValue;
-          
+
           if (filterType && filterValue) {
             if (this.config.multiSelect) {
               this.toggleFilter(filterType, filterValue);

--- a/static/js/search_filter.js
+++ b/static/js/search_filter.js
@@ -63,6 +63,10 @@
         filterFieldMap: options.filterFieldMap || {},
         filterLabels: options.filterLabels || {},
         badgeClass: options.badgeClass || 'badge rounded-pill text-bg-vhpteal',
+        // Per-filter-type pill colour, e.g. { 'case-study': 'vhppink-distinct' }.
+        // The value is just the VHP colour token; JS builds `text-bg-<token>`.
+        // Falls back to `badgeClass` for any type not listed here.
+        filterColors: options.filterColors || {},
         initTooltips: options.initTooltips !== undefined ? options.initTooltips : true,
         tooltipSelector: options.tooltipSelector || '[data-bs-toggle="tooltip"]',
         showFilterPanel: options.showFilterPanel || false,
@@ -97,13 +101,22 @@
         this.initializeTooltips();
       }
 
-      // Show filter panel if filters are active
-      if (this.config.showFilterPanel && this.elements.filterPanel) {
+      // Show filter panel if filters are active, OR if the previous navigation
+      // was a Clear (sessionStorage flag set in clearFilters); restoring the
+      // panel lets the user pick different filters without re-opening it.
+      let shouldShowPanel = this.config.showFilterPanel;
+      try {
+        if (sessionStorage.getItem('vhp-filter-panel-open') === '1') {
+          shouldShowPanel = true;
+          sessionStorage.removeItem('vhp-filter-panel-open');
+        }
+      } catch (e) { /* sessionStorage unavailable (e.g. private mode) */ }
+      if (shouldShowPanel && this.elements.filterPanel) {
         this.elements.filterPanel.style.display = 'block';
       }
 
       // Update display
-      this.updateFilterDisplay();
+      this.refreshConditionalItems();
     },
 
     /**
@@ -215,7 +228,7 @@
     setFilter(type, value) {
       if (!this.selectedFilters.hasOwnProperty(type)) return;
       this.selectedFilters[type] = value;
-      this.updateFilterDisplay();
+      this.refreshConditionalItems();
     },
 
     /**
@@ -224,7 +237,7 @@
     removeFilterSingle(type) {
       if (!this.selectedFilters.hasOwnProperty(type)) return;
       this.selectedFilters[type] = '';
-      this.updateFilterDisplay();
+      this.refreshConditionalItems();
     },
 
     /**
@@ -240,7 +253,7 @@
         this.selectedFilters[type].push(value);
       }
       
-      this.updateFilterDisplay();
+      this.refreshConditionalItems();
       this.updateDropdownVisuals();
     },
 
@@ -255,7 +268,7 @@
         this.selectedFilters[type].splice(index, 1);
       }
       
-      this.updateFilterDisplay();
+      this.refreshConditionalItems();
       this.updateDropdownVisuals();
     },
 
@@ -334,7 +347,11 @@
      */
     createFilterTag(type, value) {
       const tag = document.createElement('span');
-      tag.className = `${this.config.badgeClass} d-inline-flex align-items-center text-wrap`;
+      const colorToken = this.config.filterColors[type];
+      const baseClass = colorToken
+        ? `badge rounded-pill text-bg-${colorToken}`
+        : this.config.badgeClass;
+      tag.className = `${baseClass} d-inline-flex align-items-center text-wrap`;
       
       const label = this.config.filterLabels[type] || type;
       const removeHandler = this.config.multiSelect ? 
@@ -374,8 +391,36 @@
         });
       }
 
+      // Show a small inline spinner inside the search bar so users see
+      // *something* during the 1-5s server round-trip. With ~10-20 users/month
+      // the result cache rarely hits, so most submits are cold-path.
+      this.showLoadingIndicator();
+
       // Submit the form
       this.elements.form.submit();
+    },
+
+    /**
+     * Swap the Search submit button's content to a Bootstrap spinner +
+     * "Searching…" label and disable it. Standard Bootstrap pattern -- no
+     * absolute positioning, no overlay, no template changes. The page is
+     * about to navigate, so the original button content is restored on its
+     * own when the new HTML replaces the document.
+     */
+    showLoadingIndicator() {
+      if (!this.elements.form) return;
+      const submitBtn = this.elements.form.querySelector('button[type="submit"]');
+      if (!submitBtn || submitBtn.dataset.vhpLoading === '1') return;
+      // Lock the button's current size so swapping its content for the
+      // (narrower) spinner doesn't cause a layout shift.
+      const rect = submitBtn.getBoundingClientRect();
+      submitBtn.style.width = `${rect.width}px`;
+      submitBtn.style.height = `${rect.height}px`;
+      submitBtn.dataset.vhpLoading = '1';
+      submitBtn.disabled = true;
+      submitBtn.innerHTML =
+        '<span class="spinner-border spinner-border-sm align-middle" role="status" aria-hidden="true"></span>' +
+        '<span class="visually-hidden">Searching…</span>';
     },
 
     /**
@@ -424,9 +469,85 @@
     },
 
     /**
+     * Refresh visibility of dependent filter items based on currently-selected
+     * parent filter values. Generic: any item carrying `data-applies-to-<kind>`
+     * is shown only when at least one currently-selected item has a matching
+     * `data-<kind>` value (or when no item with `data-<kind>` is selected at
+     * all — i.e. no parent restriction). Items that become hidden while
+     * selected are auto-deselected so they don't leak into the next submit.
+     * Driven purely by data attributes; no filter-type pairing baked into JS.
+     */
+    refreshConditionalItems() {
+      const allItems = document.querySelectorAll('.dropdown-item[data-filter-type]');
+
+      // 1) Discover which "kinds" any dependent items rely on.
+      const kinds = new Set();
+      allItems.forEach(item => {
+        for (const attr of item.attributes) {
+          if (attr.name.startsWith('data-applies-to-')) {
+            kinds.add(attr.name.slice('data-applies-to-'.length));
+          }
+        }
+      });
+
+      // 2) For each kind, collect the set of values for which a parent item is
+      // currently selected.
+      const parentSelections = {};
+      kinds.forEach(k => { parentSelections[k] = new Set(); });
+      allItems.forEach(item => {
+        const type = item.dataset.filterType;
+        const val = item.dataset.filterValue;
+        const sel = this.selectedFilters[type];
+        const isSelected = Array.isArray(sel) ? sel.includes(val) : sel === val;
+        if (!isSelected) return;
+        kinds.forEach(k => {
+          const v = item.getAttribute(`data-${k}`);
+          if (v) parentSelections[k].add(v);
+        });
+      });
+
+      // 3) Apply visibility + auto-deselect items hidden while selected.
+      allItems.forEach(item => {
+        let visible = true;
+        for (const attr of item.attributes) {
+          if (!attr.name.startsWith('data-applies-to-')) continue;
+          const kind = attr.name.slice('data-applies-to-'.length);
+          const required = attr.value;
+          if (!required) continue;             // empty dependency = no restriction
+          const sel = parentSelections[kind];
+          if (!sel || sel.size === 0) continue; // no parent of this kind selected
+          if (!sel.has(required)) { visible = false; break; }
+        }
+        item.parentElement.style.display = visible ? '' : 'none';
+        if (!visible) {
+          const type = item.dataset.filterType;
+          const val = item.dataset.filterValue;
+          const cur = this.selectedFilters[type];
+          if (Array.isArray(cur)) {
+            const idx = cur.indexOf(val);
+            if (idx > -1) cur.splice(idx, 1);
+          } else if (cur === val) {
+            this.selectedFilters[type] = '';
+          }
+        }
+      });
+
+      // 4) Reflect any state changes in the badge/dropdown UI.
+      this.updateFilterDisplay();
+      if (this.config.multiSelect) this.updateDropdownVisuals();
+    },
+
+    /**
      * Clear all filters
      */
     clearFilters() {
+      // Track whether any filter was actually set, so we only trigger a
+      // navigation when there's something to clear (idempotent otherwise).
+      const hadAny = this.config.filterTypes.some(type => {
+        const v = this.selectedFilters[type];
+        return Array.isArray(v) ? v.length > 0 : !!v;
+      });
+
       // Reset all filters
       this.config.filterTypes.forEach(type => {
         if (this.config.multiSelect) {
@@ -436,10 +557,24 @@
         }
       });
 
-      this.updateFilterDisplay();
-      
+      this.refreshConditionalItems();
+
       if (this.config.multiSelect) {
         this.updateDropdownVisuals();
+      }
+
+      // Re-apply with the (now empty) filters so the page navigates to a
+      // clean state. Mirrors the Apply button's behaviour so Clear is a
+      // single user action instead of clear-then-apply. Persist a
+      // "panel was open" flag in sessionStorage so the new page restores it
+      // (otherwise the user can't pick different filters without re-opening
+      // the panel). On the no-op path (nothing was set), just close the
+      // panel as a soft UI hint.
+      if (hadAny) {
+        try { sessionStorage.setItem('vhp-filter-panel-open', '1'); } catch (e) {}
+        this.applyFilters();
+      } else if (this.elements.filterPanel) {
+        this.elements.filterPanel.style.display = 'none';
       }
     }
   };

--- a/static/js/search_filter.js
+++ b/static/js/search_filter.js
@@ -281,12 +281,23 @@
       document.querySelectorAll('.dropdown-item[data-filter-type]').forEach(item => {
         const filterType = item.dataset.filterType;
         const filterValue = item.dataset.filterValue;
-        
-        if (this.selectedFilters[filterType] && 
-            this.selectedFilters[filterType].includes(filterValue)) {
+        const isActive =
+          this.selectedFilters[filterType] &&
+          this.selectedFilters[filterType].includes(filterValue);
+
+        // Active state colour matches the filter's own pill/button colour
+        // via Bootstrap's `text-bg-<token>` utility (handles contrast text
+        // automatically). Falls back to plain `.active` when no colour token
+        // is configured for this filter type.
+        const colorToken = this.config.filterColors[filterType];
+        const colorClass = colorToken ? `text-bg-${colorToken}` : null;
+
+        if (isActive) {
           item.classList.add('active');
+          if (colorClass) item.classList.add(colorClass);
         } else {
           item.classList.remove('active');
+          if (colorClass) item.classList.remove(colorClass);
         }
       });
     },

--- a/static/js/search_filter.js
+++ b/static/js/search_filter.js
@@ -358,9 +358,13 @@
         `removeFilterTag('${type}', '${value.replace(/'/g, "\\'")}')` :
         `removeFilterTag('${type}')`;
       
+      // type="button" is critical: the badge sits inside the search form, and
+      // <button> defaults to type="submit", which would submit the form with
+      // the *old* hidden-input values (before applyFilters has written the
+      // new state in), making the X click look like a no-op page reload.
       tag.innerHTML = `
         ${label}: ${value}
-        <button class="btn-close btn-close-white ms-2" onclick="${removeHandler}" aria-label="Remove filter"></button>
+        <button type="button" class="btn-close btn-close-white ms-2" onclick="${removeHandler}" aria-label="Remove filter"></button>
       `;
       
       this.elements.filterTags.appendChild(tag);

--- a/templates/_pagination.html
+++ b/templates/_pagination.html
@@ -1,0 +1,36 @@
+{# Pagination + result count. Expects: page, page_size, total, has_prev,
+   has_next in scope. Inherits all current query params from request.args,
+   only overriding `page` so filters/search/page_size are preserved. The
+   caller may set `extra_class` via `{% with %}` to tweak vertical spacing. #}
+{% if total and total > 0 %}
+  {% set start = (page - 1) * page_size + 1 %}
+  {% set end = [page * page_size, total] | min %}
+  {% set pagination_args = request.args.to_dict(flat=False) %}
+  {% set _ = pagination_args.pop('page', None) %}
+  <nav aria-label="Page navigation"
+       class="pagination-container d-flex align-items-center flex-wrap gap-2 {{ extra_class | default('pt-3 pt-sm-2 pb-3') }}">
+    <div style="flex: 1 1 0;"></div>
+    <ul class="pagination mb-0">
+      <li class="page-item {% if not has_prev %}disabled{% endif %}">
+        <a class="page-link"
+           href="{{ url_for(request.endpoint, page=page-1, **pagination_args) }}"
+           aria-label="Previous">
+          <i class="bi bi-caret-left-fill" aria-hidden="true"></i>
+        </a>
+      </li>
+      <li class="page-item active" aria-current="page">
+        <span class="page-link bg-secondary border-secondary">{{ page }}</span>
+      </li>
+      <li class="page-item {% if not has_next %}disabled{% endif %}">
+        <a class="page-link"
+           href="{{ url_for(request.endpoint, page=page+1, **pagination_args) }}"
+           aria-label="Next">
+          <i class="bi bi-caret-right-fill" aria-hidden="true"></i>
+        </a>
+      </li>
+    </ul>
+    <div class="text-end text-secondary small" style="flex: 1 1 0;">
+      Showing {{ start }}–{{ end }} of {{ total }} results
+    </div>
+  </nav>
+{% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,7 +36,7 @@
     {% block head %}{% endblock %}
   </head>
 
-  <nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom fixed-top">
+  <nav class="navbar navbar-expand-xl navbar-light bg-white border-bottom fixed-top">
     <div class="container-fluid d-flex align-items-center justify-content-between">
 
     <!-- Logo -->
@@ -58,7 +58,7 @@
 
 
   <!-- Desktop buttons (hidden on mobile) -->
-  <div class="d-none d-lg-flex align-items-center gap-3">
+  <div class="d-none d-xl-flex align-items-center gap-3">
     
     <!-- Glossary Toggle Switch -->
     <div class="form-check form-switch mb-0 text-nowrap" data-vhp-glossary-skip>

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -68,7 +68,7 @@
             
             <!-- Selected Filters Display -->
             <div id="selected-filters" class="input-group">
-                <span class="input-group-text" id="filters_label">Selected Filters:</span>
+                <span class="input-group-text" id="filters_label">Selected Filters (OR):</span>
                 <div id="filter-tags"
                     class="form-control d-flex flex-wrap align-items-center gap-2"
                     aria-describedby="filters_label"

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -68,7 +68,7 @@
             
             <!-- Selected Filters Display -->
             <div id="selected-filters" class="input-group">
-                <span class="input-group-text" id="filters_label">Selected Filters (OR):</span>
+                <span class="input-group-text" id="filters_label">Selected Filters: <i class="bi bi-question-circle text-vhpblue ms-1" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="Multiple selections in one category match any (OR); combining categories requires all (AND)."></i></span>
                 <div id="filter-tags"
                     class="form-control d-flex flex-wrap align-items-center gap-2"
                     aria-describedby="filters_label"

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -12,10 +12,8 @@
     <nav class="navbar navbar-expand-lg d-inline">
         <form method="GET" action="{{ url_for('data') }}" class="d-flex" role="search" id="search-form">
             <input type="text" class="form-control me-2" name="query" id="search-input" value="{{ search_query or '' }}" placeholder="Search for datasets (e.g., S-ONTX26, toxicity, liver...)" />
-            <!-- Hidden inputs for filters -->
-            <input type="hidden" name="filter_case_study" id="filter_case_study" value="{{ filter_case_study or '' }}" />
-            <input type="hidden" name="filter_regulatory_question" id="filter_regulatory_question" value="{{ filter_regulatory_question or '' }}" />
-            <input type="hidden" name="filter_flow_step" id="filter_flow_step" value="{{ filter_flow_step or '' }}" />
+            <!-- Filter hidden inputs are added dynamically by search_filter.js
+                 in multipleInputs mode (one <input> per selected value). -->
             <div class="btn-group" role="group" aria-label="Search and filter buttons">
                 <button type="submit" class="btn btn-outline-vhpblue">Search</button>
                 <a href="{{ url_for('data') }}" class="btn btn-outline-danger text-nowrap">Clear</a>
@@ -92,10 +90,10 @@
     <div class="alert alert-info">
         <strong>Filters Active:</strong> Showing {{ hits_returned }} results
         {% if not page_size_met %}(fetched {{ pages_fetched }} page(s), timeout reached){% endif %}
-        | 
-        {% if filter_case_study %}<span class="badge bg-vhppink-distinct text-white">Case Study: {{ filter_case_study }}</span> {% endif %}
-        {% if filter_flow_step %}<span class="badge bg-vhppurple">Flow Step: {{ filter_flow_step }}</span> {% endif %}
-        {% if filter_regulatory_question %}<span class="badge bg-vhppink-distinct">Regulatory Question: {{ filter_regulatory_question }}</span> {% endif %}
+        |
+        {% for v in filter_case_study %}<span class="badge bg-vhppink-distinct text-white">Case Study: {{ v }}</span> {% endfor %}
+        {% for v in filter_flow_step %}<span class="badge bg-vhppurple">Flow Step: {{ v }}</span> {% endfor %}
+        {% for v in filter_regulatory_question %}<span class="badge bg-vhppink-distinct">Regulatory Question: {{ v }}</span> {% endfor %}
     </div>
     {% endif %}
 
@@ -243,11 +241,12 @@
     document.addEventListener('DOMContentLoaded', () => {
         SearchFilter.init({
             filterTypes: ['case-study', 'flow-step', 'reg-question'],
-            multiSelect: false, // Single selection per category
+            multiSelect: true, // Multiple selections per category
+            multipleInputs: true, // Create separate hidden input for each value
             initialFilters: {
-                'case-study': '{{ filter_case_study or "" }}',
-                'flow-step': '{{ filter_flow_step or "" }}',
-                'reg-question': '{{ filter_regulatory_question or "" }}'
+                'case-study': [{% for c in filter_case_study %}'{{ c }}'{% if not loop.last %}, {% endif %}{% endfor %}],
+                'flow-step': [{% for s in filter_flow_step %}'{{ s }}'{% if not loop.last %}, {% endif %}{% endfor %}],
+                'reg-question': [{% for q in filter_regulatory_question %}'{{ q }}'{% if not loop.last %}, {% endif %}{% endfor %}]
             },
             filterFieldMap: {
                 'case-study': 'filter_case_study',

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -207,7 +207,7 @@
     // Initialize search and filter functionality for data catalog
     document.addEventListener('DOMContentLoaded', () => {
         SearchFilter.init({
-            filterTypes: ['case-study', 'flow-step', 'reg-question'],
+            filterTypes: ['case-study', 'reg-question', 'flow-step'],
             multiSelect: true, // Multiple selections per category
             multipleInputs: true, // Create separate hidden input for each value
             initialFilters: {

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -98,23 +98,7 @@
     {% endif %}
 
     <!-- Pagination (top) -->
-    <nav aria-label="Page navigation" class="pagination-container d-flex justify-content-center pt-3 pt-sm-2 pb-3">
-        <ul class="pagination mb-0">
-            <li class="page-item {% if not has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('data', page=page-1, page_size=page_size, query=search_query, filter_case_study=filter_case_study, filter_regulatory_question=filter_regulatory_question, filter_flow_step=filter_flow_step) }}" aria-label="Previous">
-                    <i class="bi bi-caret-left-fill" aria-hidden="true"></i>
-                </a>
-            </li>
-            <li class="page-item active" aria-current="page">
-                <span class="page-link bg-secondary border-secondary">{{ page }}</span>
-            </li>
-            <li class="page-item {% if not has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('data', page=page+1, page_size=page_size, query=search_query, filter_case_study=filter_case_study, filter_regulatory_question=filter_regulatory_question, filter_flow_step=filter_flow_step) }}" aria-label="Next">
-                    <i class="bi bi-caret-right-fill" aria-hidden="true"></i>
-                </a>
-            </li>
-        </ul>
-    </nav>
+    {% include "_pagination.html" %}
 
     <div class="results-section">
         <div id="results-list" class="results-list">
@@ -216,23 +200,9 @@
     </div>
 
     <!-- Pagination at bottom -->
-    <nav aria-label="Page navigation" class="pagination-container mt-auto d-flex justify-content-center py-3">
-        <ul class="pagination mb-0">
-            <li class="page-item {% if not has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('data', page=page-1, page_size=page_size, query=search_query, filter_case_study=filter_case_study, filter_regulatory_question=filter_regulatory_question, filter_flow_step=filter_flow_step) }}" aria-label="Previous">
-                    <i class="bi bi-caret-left-fill" aria-hidden="true"></i>
-                </a>
-            </li>
-            <li class="page-item active" aria-current="page">
-                <span class="page-link bg-secondary border-secondary">{{ page }}</span>
-            </li>
-            <li class="page-item {% if not has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('data', page=page+1, page_size=page_size, query=search_query, filter_case_study=filter_case_study, filter_regulatory_question=filter_regulatory_question, filter_flow_step=filter_flow_step) }}" aria-label="Next">
-                    <i class="bi bi-caret-right-fill" aria-hidden="true"></i>
-                </a>
-            </li>
-        </ul>
-    </nav>
+    {% with extra_class="mt-auto py-3" %}
+        {% include "_pagination.html" %}
+    {% endwith %}
 </section>
 
 <script src="/static/js/search_filter.js"></script>

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -5,7 +5,7 @@
 <section class="container py-md-5 py-3 d-flex flex-column min-vh-100">
     <!-- Page Title and Description -->
     <div data-vhp-glossary-skip class="">
-        <h1><span class="text-vhpblue" id="collection-name">{{ collection_name or 'Data catalog' }} Data</span></h1>
+        <h1><span class="text-vhpblue" id="collection-name">Data</span></h1>
         <p class="text-secondary fs-5">Explore datasets generated or used in <span id="collection-name-sub">{{ collection_name }} and hosted on BioStudies or Zenodo archives.</span></p>
     </div>
 
@@ -28,19 +28,32 @@
             <div class="gap-2 pb-1">
                 <!-- Case Study Dropdown -->
                 <div class="btn-group mb-1">
-                    <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
+                    <button class="btn btn-sm btn-vhppink-distinct dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
                         Case Study
                     </button>
                     <ul class="dropdown-menu">
-                        <li><a class="dropdown-item" href="#" data-filter-type="case-study" data-filter-value="Thyroid">Thyroid</a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="case-study" data-filter-value="Kidney">Kidney</a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="case-study" data-filter-value="Parkinson">Parkinson</a></li>
+                        {% for slug in case_studies %}
+                          <li><a class="dropdown-item" href="#" data-filter-type="case-study" data-filter-value="{{ slug|title }}" data-case-slug="{{ slug }}">{{ slug|title }}</a></li>
+                        {% endfor %}
                     </ul>
                 </div>
                 
-                <!-- Flow Step Dropdown -->
+                
+                <!-- Regulatory Questions Dropdown -->
                 <div class="btn-group mb-1">
-                    <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
+                    <button class="btn btn-sm btn-vhppink-distinct dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
+                        Regulatory Question
+                    </button>
+                    <ul class="dropdown-menu">
+                        {% for question in reg_questions.keys() %}
+                          <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="{{ question }}" data-applies-to-case-slug="{{ reg_question_cases.get(question, '') }}"{% if question in reg_question_explanations %} data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations[question] }}"{% endif %}>{{ question }}{% if question in reg_question_explanations %} <i class="bi bi-question-circle text-vhpblue"></i>{% endif %}</a></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+
+                                <!-- Flow Step Dropdown -->
+                <div class="btn-group mb-1">
+                    <button class="btn btn-sm  btn-vhppurple dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
                         Flow Step
                     </button>
                     <ul class="dropdown-menu">
@@ -51,21 +64,6 @@
                         <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="External exposure" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['External exposure'] }}">External exposure <i class="bi bi-question-circle text-vhpblue"></i></a></li>
                         <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="Generic" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Generic'] }}">Generic <i class="bi bi-question-circle text-vhpblue"></i></a></li>
                         <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="Other" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Other'] }}">Other <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                    </ul>
-                </div>
-                
-                <!-- Regulatory Questions Dropdown -->
-                <div class="btn-group mb-1">
-                    <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
-                        Regulatory Question
-                    </button>
-                    <ul class="dropdown-menu">
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Kidney Case Study (a)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Kidney Case Study (a)'] }}">Kidney Case Study (a) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Kidney Case Study (b)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Kidney Case Study (b)'] }}">Kidney Case Study (b) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Parkinson Case Study (a)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Parkinson Case Study (a)'] }}">Parkinson Case Study (a) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Parkinson Case Study (b)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Parkinson Case Study (b)'] }}">Parkinson Case Study (b) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Thyroid Case Study (a)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Thyroid Case Study (a)'] }}">Thyroid Case Study (a) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Thyroid Case Study (b)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Thyroid Case Study (b)'] }}">Thyroid Case Study (b) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
                     </ul>
                 </div>
             </div>
@@ -262,6 +260,11 @@
                 'reg-question': 'Reg. Question'
             },
             badgeClass: 'badge rounded-pill text-bg-vhpblue',
+            filterColors: {
+                'case-study': 'vhppink-distinct',
+                'reg-question': 'vhppink-distinct',
+                'flow-step': 'vhppurple',
+            },
             showFilterPanel: {% if filter_case_study or filter_flow_step or filter_regulatory_question %}true{% else %}false{% endif %}
         });
     });

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -22,7 +22,7 @@
         </form>
         
         <!-- Filter Panel -->
-        <div id="filter-panel" class="card bg-secondary-subtle p-3 mt-2" style="display: none;">
+        <div id="filter-panel" class="card bg-light p-3 mt-2" style="display: none;">
             <div class="gap-2 pb-1">
                 <!-- Case Study Dropdown -->
                 <div class="btn-group mb-1">
@@ -74,11 +74,8 @@
                     aria-describedby="filters_label"
                     role="group">
                 </div>
-            </div>
-            
-            <div class="">
-                <button id="apply-filter-btn" class="btn btn-sm btn-vhpblue mt-2">Apply</button>
-                <button id="clear-filter-btn" class="btn btn-sm btn-outline-danger mt-2">Clear</button>
+                <button id="apply-filter-btn" class="btn btn-vhpblue" aria-label="Apply filters" title="Apply filters"><i class="bi bi-check-lg" aria-hidden="true"></i></button>
+                <button id="clear-filter-btn" class="btn btn-outline-danger" aria-label="Clear filters" title="Clear filters"><i class="bi bi-x-lg" aria-hidden="true"></i></button>
             </div>
         </div>
         

--- a/templates/home.html
+++ b/templates/home.html
@@ -83,7 +83,7 @@
             Select an <i>in vitro</i> method to perform your safety assessment.
             </div>
             <div class="card-footer text-body-secondary">
-              <span class="badge rounded-pill bg-vhpblue text-white">{{18}}</span> methods
+              <span class="badge rounded-pill bg-vhpblue text-white">{{ num_methods }}</span> methods
             </div>
           </div>
         </div>

--- a/templates/methods/methods.html
+++ b/templates/methods/methods.html
@@ -137,7 +137,7 @@
     // Initialize search and filter functionality for methods catalog
     document.addEventListener('DOMContentLoaded', () => {
         SearchFilter.init({
-            filterTypes: ['case-study', 'flow-step', 'reg-question'],
+            filterTypes: ['case-study', 'reg-question', 'flow-step'],
             multiSelect: true, // Multiple selections per category
             multipleInputs: true, // Create separate hidden input for each value
             initialFilters: {

--- a/templates/methods/methods.html
+++ b/templates/methods/methods.html
@@ -15,7 +15,7 @@
     <div class="">
         <h1><span class="text-vhpblue" id="collection-name">Methods</span></h1>
         <p class="text-secondary fs-5"> Explore methods developed by and/or used in VHP4Safety. </p>
-        <p>You can search for a method that you know using the search box below. Alternatively, you can filter the methods with respect to the <a class="link-vhpblue text-decoration-none" href="{{ url_for('workflows') }}#about-section">case studies' flow step</a> that they belong to and/or the regulatory question that they are associated with. Use the "Filters" button to show filter options, then "Apply Filter" to see results, and click "Clear Filter" to reset the filters.</p>
+        <p>You can search for a method that you know using the search box below. Alternatively, you can filter the methods with respect to the <a class="link-vhpblue text-decoration-none" href="{{ url_for('workflows') }}#about-section">case studies' flow step</a> that they belong to and/or the regulatory question that they are associated with. Use the "Filters" button to show filter options, then "OK" to see results, and click "X" to reset the filters.</p>
 
     </div>
 

--- a/templates/methods/methods.html
+++ b/templates/methods/methods.html
@@ -34,56 +34,39 @@
         
         <!-- Filter Panel -->
         <div id="filter-panel" class="card bg-secondary-subtle p-3 mt-2" style="display: none;">
-  <!-- explanation of the generic risk-assessment process flow -->
-  <div class="">
-    <h3><span class="text-vhpblue" id="collection-name">Safety Assessment Workflow Steps</span></h3>
-    <p class="mb-4">The Virtual Human Platform implements a generic safety assessment as a five-step process. For more information regarding the Safety Assessment Workflow, visit our <a class="link-vhpblue text-decoration-none" href="{{ url_for('SafetyAssessmentWorkflow') }}" >Safety Assessment Workflow info page.</a> <p>
-    </p>
-  </div>
-  <div class="row row-cols-1 row-cols-md-6 gap-2 mx-auto">
-    <button class="btn btn-primary btn-vhpblue card-button-vhpblue" type="submit"
-      data-bs-toggle="methodtip" data-bs-placement="top" title="Chemical characteristics and hazard identification is a Safety Assessment Workflow Step that categorizes services that use molecular structures, chemical descriptors, and databases to predict or analyze the properties, behavior, and potential risks of chemical substances.">
-      Chemical Characteristics and hazard identification</button>
-    <button class="btn btn-primary btn-vhpblue card-button-vhpblue" type="submit"
-      data-bs-toggle="methodtip" data-bs-placement="top" title="Exposure is a Safety Assessment Workflow Step which categorizes services that evaluate and analyze the route, duration, magnitude and frequency of exposure of an organism or (sub)population to one or multiple chemicals.">
-      Exposure</button>
-    <button class="btn btn-primary btn-vhpblue card-button-vhpblue" type="submit"
-      data-bs-toggle="methodtip" data-bs-placement="top" title="Toxicokinetics is a Safety Assessment Workflow Step which categorizes services that analyze the kinetics (absorption, distribution, metabolism and excretion) of chemicals and how these processes influence the internal dose.">
-      Toxicokinetics </button>
-    <button class="btn btn-primary btn-vhpblue card-button-vhpblue" type="submit"
-      data-bs-toggle="methodtip" data-bs-placement="top" title="Toxicodynamics is a Safety Assessment Workflow Step which categorizes services that use or extend the (quantitative) AOP framework to analyze and assess the interaction of chemicals with biological targets.">
-      Toxicodynamics</button>
-    <button class="btn btn-primary btn-vhpblue card-button-vhpblue" type="submit"
-      data-bs-toggle="methodtip" data-bs-placement="top" title="Adverse Outcome is a Safety Assessment Workflow Step which specifically refers to clinical and epidemiological effects. It categorizes services that provide information on the toxicological endpoints and adverse outcomes at a clinical or epidemiological level of chemical exposures.">
-      Adverse Outcome</button>
-  </div>
-  <div class=""><p>&nbsp;</p></div> <!-- how to do this properly?? -->
-
             <div class="gap-2 pb-1">
-                <!-- Flow Step Dropdown -->
+                <!-- Case Study Dropdown -->
                 <div class="btn-group mb-1">
-                    <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
-                        Safety Assessment Workflow Step
+                    <button class="btn btn-sm btn-vhppink-distinct dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
+                        Case Study
                     </button>
                     <ul class="dropdown-menu">
-                        {% for stage in stages %}
-                        <li><a class="dropdown-item " href="#" data-filter-type="flow-step" data-filter-value="{{ stage }}"{% if stage in stage_explanations %} data-bs-toggle="methodtip" data-bs-placement="right" data-bs-title="{{ stage_explanations[stage] }}"{% endif %}>
-                            {{ stage }}{% if stage in stage_explanations %} <i class="text-vhpblue bi bi-question-circle"></i>{% endif %}
-                        </a></li>
+                        {% for slug in case_studies %}
+                          <li><a class="dropdown-item" href="#" data-filter-type="case-study" data-filter-value="{{ slug|title }}" data-case-slug="{{ slug }}">{{ slug|title }}</a></li>
                         {% endfor %}
                     </ul>
                 </div>
-                
+
                 <!-- Regulatory Questions Dropdown -->
                 <div class="btn-group mb-1">
-                    <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
+                    <button class="btn btn-sm btn-vhppink-distinct dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
                         Regulatory Question
                     </button>
                     <ul class="dropdown-menu">
                         {% for question in reg_questions.keys() %}
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="{{ question }}" data-applies-to-case-slug="{{ reg_question_cases.get(question, '') }}"{% if question in reg_question_explanations %} data-bs-toggle="methodtip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations[question] }}"{% endif %}>
-                            {{ question }}{% if question in reg_question_explanations %} <i class="text-vhpblue bi bi-question-circle"></i>{% endif %}
-                        </a></li>
+                          <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="{{ question }}" data-applies-to-case-slug="{{ reg_question_cases.get(question, '') }}"{% if question in reg_question_explanations %} data-bs-toggle="methodtip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations[question] }}"{% endif %}>{{ question }}{% if question in reg_question_explanations %} <i class="bi bi-question-circle text-vhpblue"></i>{% endif %}</a></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+
+                <!-- Flow Step Dropdown -->
+                <div class="btn-group mb-1">
+                    <button class="btn btn-sm btn-vhppurple dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
+                        Flow Step
+                    </button>
+                    <ul class="dropdown-menu">
+                        {% for stage in stages %}
+                          <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="{{ stage }}"{% if stage in stage_explanations %} data-bs-toggle="methodtip" data-bs-placement="right" data-bs-title="{{ stage_explanations[stage] }}"{% endif %}>{{ stage }}{% if stage in stage_explanations %} <i class="bi bi-question-circle text-vhpblue"></i>{% endif %}</a></li>
                         {% endfor %}
                     </ul>
                 </div>
@@ -187,18 +170,21 @@
     // Initialize search and filter functionality for methods catalog
     document.addEventListener('DOMContentLoaded', () => {
         SearchFilter.init({
-            filterTypes: ['flow-step', 'reg-question'],
+            filterTypes: ['case-study', 'flow-step', 'reg-question'],
             multiSelect: true, // Multiple selections per category
             multipleInputs: true, // Create separate hidden input for each value
             initialFilters: {
+                'case-study': [{% for c in selected_case_studies %}'{{ c }}'{% if not loop.last %}, {% endif %}{% endfor %}],
                 'flow-step': [{% for stage in selected_stages %}'{{ stage }}'{% if not loop.last %}, {% endif %}{% endfor %}],
                 'reg-question': [{% for question in selected_questions %}'{{ question }}'{% if not loop.last %}, {% endif %}{% endfor %}]
             },
             filterFieldMap: {
+                'case-study': 'case_study',
                 'flow-step': 'stage',
                 'reg-question': 'reg_q'
             },
             filterLabels: {
+                'case-study': 'Case Study',
                 'flow-step': 'Flow Step',
                 'reg-question': 'Reg. Q'
             },
@@ -209,7 +195,7 @@
                 'flow-step': 'vhppurple',
             },
             tooltipSelector: '[data-bs-toggle="methodtip"]',
-            showFilterPanel: {% if selected_stages or selected_questions %}true{% else %}false{% endif %}
+            showFilterPanel: {% if selected_case_studies or selected_stages or selected_questions %}true{% else %}false{% endif %}
         });
     });
 </script>

--- a/templates/methods/methods.html
+++ b/templates/methods/methods.html
@@ -74,7 +74,7 @@
             
             <!-- Selected Filters Display -->
             <div id="selected-filters" class="input-group">
-                <span class="input-group-text" id="filters_label">Selected Filters:</span>
+                <span class="input-group-text" id="filters_label">Selected Filters (OR):</span>
                 <div id="filter-tags"
                     class="form-control d-flex flex-wrap align-items-center gap-2"
                     aria-describedby="filters_label"
@@ -93,7 +93,7 @@
     <nav aria-label="Page navigation" class="pagination-container d-flex justify-content-center pt-3 pt-sm-2 pb-3">
         <ul class="pagination mb-0">
             <li class="page-item {% if not has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('methods', page=page-1, page_size=page_size, search=search_query, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Previous">
+                <a class="page-link" href="{{ url_for('methods', page=page-1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Previous">
                     <i class="bi bi-caret-left-fill" aria-hidden="true"></i>
                 </a>
             </li>
@@ -101,7 +101,7 @@
                 <span class="page-link bg-secondary border-secondary">{{ page }}</span>
             </li>
             <li class="page-item {% if not has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('methods', page=page+1, page_size=page_size, search=search_query, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Next">
+                <a class="page-link" href="{{ url_for('methods', page=page+1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Next">
                     <i class="bi bi-caret-right-fill" aria-hidden="true"></i>
                 </a>
             </li>
@@ -149,7 +149,7 @@
     <nav aria-label="Page navigation" class="pagination-container mt-auto d-flex justify-content-center py-3">
         <ul class="pagination mb-0">
             <li class="page-item {% if not has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('methods', page=page-1, page_size=page_size, search=search_query, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Previous">
+                <a class="page-link" href="{{ url_for('methods', page=page-1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Previous">
                     <i class="bi bi-caret-left-fill" aria-hidden="true"></i>
                 </a>
             </li>
@@ -157,7 +157,7 @@
                 <span class="page-link bg-secondary border-secondary">{{ page }}</span>
             </li>
             <li class="page-item {% if not has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('methods', page=page+1, page_size=page_size, search=search_query, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Next">
+                <a class="page-link" href="{{ url_for('methods', page=page+1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Next">
                     <i class="bi bi-caret-right-fill" aria-hidden="true"></i>
                 </a>
             </li>

--- a/templates/methods/methods.html
+++ b/templates/methods/methods.html
@@ -74,7 +74,7 @@
             
             <!-- Selected Filters Display -->
             <div id="selected-filters" class="input-group">
-                <span class="input-group-text" id="filters_label">Selected Filters (OR):</span>
+                <span class="input-group-text" id="filters_label">Selected Filters: <i class="bi bi-question-circle text-vhpblue ms-1" data-bs-toggle="methodtip" data-bs-placement="right" data-bs-title="Multiple selections in one category match any (OR); combining categories requires all (AND)."></i></span>
                 <div id="filter-tags"
                     class="form-control d-flex flex-wrap align-items-center gap-2"
                     aria-describedby="filters_label"

--- a/templates/methods/methods.html
+++ b/templates/methods/methods.html
@@ -33,7 +33,7 @@
         </form>
         
         <!-- Filter Panel -->
-        <div id="filter-panel" class="card bg-secondary-subtle p-3 mt-2" style="display: none;">
+        <div id="filter-panel" class="card bg-light p-3 mt-2" style="display: none;">
             <div class="gap-2 pb-1">
                 <!-- Case Study Dropdown -->
                 <div class="btn-group mb-1">
@@ -80,11 +80,8 @@
                     aria-describedby="filters_label"
                     role="group">
                 </div>
-            </div>
-            
-            <div class="">
-                <button id="apply-filter-btn" class="btn btn-sm btn-vhpblue mt-2">Apply</button>
-                <button id="clear-filter-btn" class="btn btn-sm btn-outline-danger mt-2">Clear</button>
+                <button id="apply-filter-btn" class="btn btn-vhpblue" aria-label="Apply filters" title="Apply filters"><i class="bi bi-check-lg" aria-hidden="true"></i></button>
+                <button id="clear-filter-btn" class="btn btn-outline-danger" aria-label="Clear filters" title="Clear filters"><i class="bi bi-x-lg" aria-hidden="true"></i></button>
             </div>
         </div>
     </nav>

--- a/templates/methods/methods.html
+++ b/templates/methods/methods.html
@@ -90,23 +90,7 @@
     </nav>
 
     <!-- Pagination (top) -->
-    <nav aria-label="Page navigation" class="pagination-container d-flex justify-content-center pt-3 pt-sm-2 pb-3">
-        <ul class="pagination mb-0">
-            <li class="page-item {% if not has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('methods', page=page-1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Previous">
-                    <i class="bi bi-caret-left-fill" aria-hidden="true"></i>
-                </a>
-            </li>
-            <li class="page-item active" aria-current="page">
-                <span class="page-link bg-secondary border-secondary">{{ page }}</span>
-            </li>
-            <li class="page-item {% if not has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('methods', page=page+1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Next">
-                    <i class="bi bi-caret-right-fill" aria-hidden="true"></i>
-                </a>
-            </li>
-        </ul>
-    </nav>
+    {% include "_pagination.html" %}
 
     <!-- Methods List -->
     <div class="results-section">
@@ -146,23 +130,9 @@
     </div>
 
     <!-- Pagination at bottom -->
-    <nav aria-label="Page navigation" class="pagination-container mt-auto d-flex justify-content-center py-3">
-        <ul class="pagination mb-0">
-            <li class="page-item {% if not has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('methods', page=page-1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Previous">
-                    <i class="bi bi-caret-left-fill" aria-hidden="true"></i>
-                </a>
-            </li>
-            <li class="page-item active" aria-current="page">
-                <span class="page-link bg-secondary border-secondary">{{ page }}</span>
-            </li>
-            <li class="page-item {% if not has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('methods', page=page+1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Next">
-                    <i class="bi bi-caret-right-fill" aria-hidden="true"></i>
-                </a>
-            </li>
-        </ul>
-    </nav>
+    {% with extra_class="mt-auto py-3" %}
+        {% include "_pagination.html" %}
+    {% endwith %}
 </section>
 
 <script src="/static/js/search_filter.js"></script>

--- a/templates/methods/methods.html
+++ b/templates/methods/methods.html
@@ -81,7 +81,7 @@
                     </button>
                     <ul class="dropdown-menu">
                         {% for question in reg_questions.keys() %}
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="{{ question }}"{% if question in reg_question_explanations %} data-bs-toggle="methodtip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations[question] }}"{% endif %}>
+                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="{{ question }}" data-applies-to-case-slug="{{ reg_question_cases.get(question, '') }}"{% if question in reg_question_explanations %} data-bs-toggle="methodtip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations[question] }}"{% endif %}>
                             {{ question }}{% if question in reg_question_explanations %} <i class="text-vhpblue bi bi-question-circle"></i>{% endif %}
                         </a></li>
                         {% endfor %}
@@ -144,9 +144,9 @@
 
                             <!-- Method Webpage -->
                             {% if item.main_url == "no_url" %}
-                                <a type="button" class="btn btn-outline-vhppink disabled" data-bs-toggle="methodtip" data-bs-title="No webpage available"><i class="bi bi-box-arrow-up-right"></i></a>
+                                <a type="button" class="btn btn-outline-vhpblue disabled" data-bs-toggle="methodtip" data-bs-title="No webpage available"><i class="bi bi-box-arrow-up-right"></i></a>
                             {% else %}
-                                <a type="button" href="{{ item.main_url }}" class="btn btn-outline-vhppink" target="_blank" data-bs-toggle="methodtip" data-bs-title="Visit main webpage"><i class="bi bi-box-arrow-up-right"></i></a>
+                                <a type="button" href="{{ item.main_url }}" class="btn btn-outline-vhpblue" target="_blank" data-bs-toggle="methodtip" data-bs-title="Visit main webpage"><i class="bi bi-box-arrow-up-right"></i></a>
                             {% endif %}
 
                             <!-- Meta-Data 
@@ -155,7 +155,9 @@
                     </div>
                 </div>
             {% else %}
-                <li>No methods found.</li>
+                <li style="list-style: none;">
+                    <div class="card alert alert-warning mb-0 justify-content-center align-items-center">No methods found</div>
+                </li>
             {% endfor %}
         </ul>
     </div>
@@ -201,6 +203,11 @@
                 'reg-question': 'Reg. Q'
             },
             badgeClass: 'badge rounded-pill text-bg-vhpblue',
+            filterColors: {
+                'case-study': 'vhppink-distinct',
+                'reg-question': 'vhppink-distinct',
+                'flow-step': 'vhppurple',
+            },
             tooltipSelector: '[data-bs-toggle="methodtip"]',
             showFilterPanel: {% if selected_stages or selected_questions %}true{% else %}false{% endif %}
         });

--- a/templates/models_page.html
+++ b/templates/models_page.html
@@ -182,7 +182,7 @@
     // Initialize search and filter functionality for data catalog
     document.addEventListener('DOMContentLoaded', () => {
         SearchFilter.init({
-            filterTypes: ['case-study', 'flow-step', 'reg-question'],
+            filterTypes: ['case-study', 'reg-question', 'flow-step'],
             multiSelect: false, // Single selection per category
             initialFilters: {
                 'case-study': '{{ filter_case_study or "" }}',

--- a/templates/models_page.html
+++ b/templates/models_page.html
@@ -25,7 +25,7 @@
         </form>
         
         <!-- Filter Panel -->
-        <div id="filter-panel" class="card bg-secondary-subtle p-3 mt-2" style="display: none;">
+        <div id="filter-panel" class="card bg-light p-3 mt-2" style="display: none;">
             <div class="gap-2 pb-1">
                 <!-- Case Study Dropdown -->
                 <div class="btn-group mb-1">
@@ -76,11 +76,8 @@
                     aria-describedby="filters_label"
                     role="group">
                 </div>
-            </div>
-            
-            <div class="">
-                <button id="apply-filter-btn" class="btn btn-sm btn-vhpblue mt-2">Apply</button>
-                <button id="clear-filter-btn" class="btn btn-sm btn-outline-danger mt-2">Clear</button>
+                <button id="apply-filter-btn" class="btn btn-vhpblue" aria-label="Apply filters" title="Apply filters"><i class="bi bi-check-lg" aria-hidden="true"></i></button>
+                <button id="clear-filter-btn" class="btn btn-outline-danger" aria-label="Clear filters" title="Clear filters"><i class="bi bi-x-lg" aria-hidden="true"></i></button>
             </div>
         </div>
         

--- a/templates/models_page.html
+++ b/templates/models_page.html
@@ -33,9 +33,9 @@
                         Case Study
                     </button>
                     <ul class="dropdown-menu">
-                        <li><a class="dropdown-item" href="#" data-filter-type="case-study" data-filter-value="Thyroid">Thyroid</a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="case-study" data-filter-value="Kidney">Kidney</a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="case-study" data-filter-value="Parkinson">Parkinson</a></li>
+                        {% for slug in case_studies %}
+                          <li><a class="dropdown-item" href="#" data-filter-type="case-study" data-filter-value="{{ slug|title }}" data-case-slug="{{ slug }}">{{ slug|title }}</a></li>
+                        {% endfor %}
                     </ul>
                 </div>
                 
@@ -61,12 +61,9 @@
                         Regulatory Question
                     </button>
                     <ul class="dropdown-menu">
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Kidney Case Study (a)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Kidney Case Study (a)'] }}">Kidney Case Study (a) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Kidney Case Study (b)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Kidney Case Study (b)'] }}">Kidney Case Study (b) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Parkinson Case Study (a)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Parkinson Case Study (a)'] }}">Parkinson Case Study (a) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Parkinson Case Study (b)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Parkinson Case Study (b)'] }}">Parkinson Case Study (b) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Thyroid Case Study (a)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Thyroid Case Study (a)'] }}">Thyroid Case Study (a) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="Thyroid Case Study (b)" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations['Thyroid Case Study (b)'] }}">Thyroid Case Study (b) <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        {% for question in reg_questions.keys() %}
+                          <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="{{ question }}" data-applies-to-case-slug="{{ reg_question_cases.get(question, '') }}"{% if question in reg_question_explanations %} data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations[question] }}"{% endif %}>{{ question }}{% if question in reg_question_explanations %} <i class="bi bi-question-circle text-vhpblue"></i>{% endif %}</a></li>
+                        {% endfor %}
                     </ul>
                 </div>
             </div>
@@ -162,7 +159,7 @@
             {% endfor %}
 
         {% else %}
-            <div class="alert alert-warning">No studies found</div>
+            <div class="card alert alert-warning mb-0 justify-content-center align-items-center">No studies found</div>
         {% endif %}
     </div>
 </div>
@@ -206,6 +203,11 @@
                 'reg-question': 'Reg. Question'
             },
             badgeClass: 'badge rounded-pill text-bg-vhpblue',
+            filterColors: {
+                'case-study': 'vhppink-distinct',
+                'reg-question': 'vhppink-distinct',
+                'flow-step': 'vhppurple',
+            },
             showFilterPanel: {% if filter_case_study or filter_flow_step or filter_regulatory_question %}true{% else %}false{% endif %}
         });
     });

--- a/templates/models_page.html
+++ b/templates/models_page.html
@@ -70,7 +70,7 @@
             
             <!-- Selected Filters Display -->
             <div id="selected-filters" class="input-group">
-                <span class="input-group-text" id="filters_label">Selected Filters (OR):</span>
+                <span class="input-group-text" id="filters_label">Selected Filters: <i class="bi bi-question-circle text-vhpblue ms-1" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="Multiple selections in one category match any (OR); combining categories requires all (AND)."></i></span>
                 <div id="filter-tags"
                     class="form-control d-flex flex-wrap align-items-center gap-2"
                     aria-describedby="filters_label"

--- a/templates/models_page.html
+++ b/templates/models_page.html
@@ -70,7 +70,7 @@
             
             <!-- Selected Filters Display -->
             <div id="selected-filters" class="input-group">
-                <span class="input-group-text" id="filters_label">Selected Filters:</span>
+                <span class="input-group-text" id="filters_label">Selected Filters (OR):</span>
                 <div id="filter-tags"
                     class="form-control d-flex flex-wrap align-items-center gap-2"
                     aria-describedby="filters_label"

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -74,7 +74,7 @@
             
             <!-- Selected Filters Display -->
             <div id="selected-filters" class="input-group">
-                <span class="input-group-text" id="filters_label">Selected Filters:</span>
+                <span class="input-group-text" id="filters_label">Selected Filters (OR):</span>
                 <div id="filter-tags"
                     class="form-control d-flex flex-wrap align-items-center gap-2"
                     aria-describedby="filters_label"
@@ -105,7 +105,7 @@
     <nav aria-label="Page navigation" class="pagination-container d-flex justify-content-center pt-3 pt-sm-2 pb-3">
         <ul class="pagination mb-0">
             <li class="page-item {% if not has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('tools', page=page-1, page_size=page_size, search=search_query, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Previous">
+                <a class="page-link" href="{{ url_for('tools', page=page-1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Previous">
                     <i class="bi bi-caret-left-fill" aria-hidden="true"></i>
                 </a>
             </li>
@@ -113,7 +113,7 @@
                 <span class="page-link bg-secondary border-secondary">{{ page }}</span>
             </li>
             <li class="page-item {% if not has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('tools', page=page+1, page_size=page_size, search=search_query, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Next">
+                <a class="page-link" href="{{ url_for('tools', page=page+1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Next">
                     <i class="bi bi-caret-right-fill" aria-hidden="true"></i>
                 </a>
             </li>
@@ -180,7 +180,7 @@
     <nav aria-label="Page navigation" class="pagination-container mt-auto d-flex justify-content-center py-3">
         <ul class="pagination mb-0">
             <li class="page-item {% if not has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('tools', page=page-1, page_size=page_size, search=search_query, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Previous">
+                <a class="page-link" href="{{ url_for('tools', page=page-1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Previous">
                     <i class="bi bi-caret-left-fill" aria-hidden="true"></i>
                 </a>
             </li>
@@ -188,7 +188,7 @@
                 <span class="page-link bg-secondary border-secondary">{{ page }}</span>
             </li>
             <li class="page-item {% if not has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('tools', page=page+1, page_size=page_size, search=search_query, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Next">
+                <a class="page-link" href="{{ url_for('tools', page=page+1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Next">
                     <i class="bi bi-caret-right-fill" aria-hidden="true"></i>
                 </a>
             </li>

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -35,6 +35,18 @@
         <!-- Filter Panel -->
         <div id="filter-panel" class="card bg-secondary-subtle p-3 mt-2" style="display: none;">
             <div class="gap-2 pb-1">
+                <!-- Case Study Dropdown (derived from reg_q_Xy booleans -- tools have no case_study field) -->
+                <div class="btn-group mb-1">
+                    <button class="btn btn-sm btn-vhppink-distinct dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
+                        Case Study
+                    </button>
+                    <ul class="dropdown-menu">
+                        {% for slug in case_studies %}
+                          <li><a class="dropdown-item" href="#" data-filter-type="case-study" data-filter-value="{{ slug|title }}" data-case-slug="{{ slug }}">{{ slug|title }}</a></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+
                 <!-- Regulatory Questions Dropdown -->
                 <div class="btn-group mb-1">
                     <button class="btn btn-sm btn-vhppink-distinct dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
@@ -189,18 +201,21 @@
     // Initialize search and filter functionality for tools catalog
     document.addEventListener('DOMContentLoaded', () => {
         SearchFilter.init({
-            filterTypes: ['flow-step', 'reg-question'],
+            filterTypes: ['case-study', 'flow-step', 'reg-question'],
             multiSelect: true, // Multiple selections per category
             multipleInputs: true, // Create separate hidden input for each value
             initialFilters: {
+                'case-study': [{% for c in selected_case_studies %}'{{ c }}'{% if not loop.last %}, {% endif %}{% endfor %}],
                 'flow-step': [{% for stage in selected_stages %}'{{ stage }}'{% if not loop.last %}, {% endif %}{% endfor %}],
                 'reg-question': [{% for question in selected_questions %}'{{ question }}'{% if not loop.last %}, {% endif %}{% endfor %}]
             },
             filterFieldMap: {
+                'case-study': 'case_study',
                 'flow-step': 'stage',
                 'reg-question': 'reg_q'
             },
             filterLabels: {
+                'case-study': 'Case Study',
                 'flow-step': 'Flow Step',
                 'reg-question': 'Reg. Q'
             },
@@ -210,7 +225,7 @@
                 'reg-question': 'vhppink-distinct',
                 'flow-step': 'vhppurple',
             },
-            showFilterPanel: {% if selected_stages or selected_questions %}true{% else %}false{% endif %}
+            showFilterPanel: {% if selected_case_studies or selected_stages or selected_questions %}true{% else %}false{% endif %}
         });
     });
 </script>

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -81,7 +81,7 @@
                     </button>
                     <ul class="dropdown-menu">
                         {% for question in reg_questions.keys() %}
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="{{ question }}"{% if question in reg_question_explanations %} data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations[question] }}"{% endif %}>
+                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="{{ question }}" data-applies-to-case-slug="{{ reg_question_cases.get(question, '') }}"{% if question in reg_question_explanations %} data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations[question] }}"{% endif %}>
                             {{ question }}{% if question in reg_question_explanations %} <i class="text-vhpblue bi bi-question-circle"></i>{% endif %}
                         </a></li>
                         {% endfor %}
@@ -186,7 +186,9 @@
                     </div>
                 </div>
             {% else %}
-                <li>No tools found.</li>
+                <li style="list-style: none;">
+                    <div class="card alert alert-warning mb-0 justify-content-center align-items-center">No tools found</div>
+                </li>
             {% endfor %}
         </ul>
     </div>
@@ -232,6 +234,11 @@
                 'reg-question': 'Reg. Q'
             },
             badgeClass: 'badge rounded-pill text-bg-vhpblue',
+            filterColors: {
+                'case-study': 'vhppink-distinct',
+                'reg-question': 'vhppink-distinct',
+                'flow-step': 'vhppurple',
+            },
             showFilterPanel: {% if selected_stages or selected_questions %}true{% else %}false{% endif %}
         });
     });

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -74,7 +74,7 @@
             
             <!-- Selected Filters Display -->
             <div id="selected-filters" class="input-group">
-                <span class="input-group-text" id="filters_label">Selected Filters (OR):</span>
+                <span class="input-group-text" id="filters_label">Selected Filters: <i class="bi bi-question-circle text-vhpblue ms-1" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="Multiple selections in one category match any (OR); combining categories requires all (AND)."></i></span>
                 <div id="filter-tags"
                     class="form-control d-flex flex-wrap align-items-center gap-2"
                     aria-describedby="filters_label"

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -168,7 +168,7 @@
     // Initialize search and filter functionality for tools catalog
     document.addEventListener('DOMContentLoaded', () => {
         SearchFilter.init({
-            filterTypes: ['case-study', 'flow-step', 'reg-question'],
+            filterTypes: ['case-study', 'reg-question', 'flow-step'],
             multiSelect: true, // Multiple selections per category
             multipleInputs: true, // Create separate hidden input for each value
             initialFilters: {

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -13,7 +13,7 @@
     <div class="">
         <h1><span class="text-vhpblue" id="collection-name">Tools</span></h1>
         <p class="text-secondary fs-5"> Explore tools developed by and/or used in VHP4Safety. </p>
-        <p>You can search for a tool that you know using the search box below. Alternatively, you can filter the tools with respect to the <a class="link-vhpblue text-decoration-none" href="{{ url_for('workflows') }}#about-section">case studies' flow step</a> that they belong to and/or the regulatory question that they are associated with. Use the "Filters" button to show filter options, then "Apply Filter" to see results, and click "Clear Filter" to reset the filters.</p>
+        <p>You can search for a tool that you know using the search box below. Alternatively, you can filter the tools with respect to the <a class="link-vhpblue text-decoration-none" href="{{ url_for('workflows') }}#about-section">case studies' flow step</a> that they belong to and/or the regulatory question that they are associated with. Use the "Filters" button to show filter options, then "OK" to see results, and click "X" to reset the filters.</p>
 
         <p class="text-secondary fs-5"> Contribution and Feedback </p>
         <p>We welcome and appreciate any feedback on this catalog of tools or the individual tools listed in it. We also appreciate receiving requests for other tools that you are aware of and deem relevant to this catalog. For these contribution and feedback, please feel free to create <a class="link-vhpblue text-decoration-none" href="https://github.com/VHP4Safety/virtual-human-platform/issues">an issue at our repository</a>.

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -33,7 +33,7 @@
         </form>
         
         <!-- Filter Panel -->
-        <div id="filter-panel" class="card bg-secondary-subtle p-3 mt-2" style="display: none;">
+        <div id="filter-panel" class="card bg-light p-3 mt-2" style="display: none;">
             <div class="gap-2 pb-1">
                 <!-- Case Study Dropdown (derived from reg_q_Xy booleans -- tools have no case_study field) -->
                 <div class="btn-group mb-1">
@@ -80,11 +80,8 @@
                     aria-describedby="filters_label"
                     role="group">
                 </div>
-            </div>
-            
-            <div class="">
-                <button id="apply-filter-btn" class="btn btn-sm btn-vhpblue mt-2">Apply</button>
-                <button id="clear-filter-btn" class="btn btn-sm btn-outline-danger mt-2">Clear</button>
+                <button id="apply-filter-btn" class="btn btn-vhpblue" aria-label="Apply filters" title="Apply filters"><i class="bi bi-check-lg" aria-hidden="true"></i></button>
+                <button id="clear-filter-btn" class="btn btn-outline-danger" aria-label="Clear filters" title="Clear filters"><i class="bi bi-x-lg" aria-hidden="true"></i></button>
             </div>
         </div>
     </nav>

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -102,23 +102,7 @@
     </div>
 
     <!-- Pagination (top) -->
-    <nav aria-label="Page navigation" class="pagination-container d-flex justify-content-center pt-3 pt-sm-2 pb-3">
-        <ul class="pagination mb-0">
-            <li class="page-item {% if not has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('tools', page=page-1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Previous">
-                    <i class="bi bi-caret-left-fill" aria-hidden="true"></i>
-                </a>
-            </li>
-            <li class="page-item active" aria-current="page">
-                <span class="page-link bg-secondary border-secondary">{{ page }}</span>
-            </li>
-            <li class="page-item {% if not has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('tools', page=page+1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Next">
-                    <i class="bi bi-caret-right-fill" aria-hidden="true"></i>
-                </a>
-            </li>
-        </ul>
-    </nav>
+    {% include "_pagination.html" %}
 
     <!-- Tools List -->
     <div class="results-section">
@@ -177,23 +161,9 @@
     </div>
 
     <!-- Pagination at bottom -->
-    <nav aria-label="Page navigation" class="pagination-container mt-auto d-flex justify-content-center py-3">
-        <ul class="pagination mb-0">
-            <li class="page-item {% if not has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('tools', page=page-1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Previous">
-                    <i class="bi bi-caret-left-fill" aria-hidden="true"></i>
-                </a>
-            </li>
-            <li class="page-item active" aria-current="page">
-                <span class="page-link bg-secondary border-secondary">{{ page }}</span>
-            </li>
-            <li class="page-item {% if not has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('tools', page=page+1, page_size=page_size, search=search_query, case_study=selected_case_studies, stage=selected_stages, reg_q=selected_questions) }}" aria-label="Next">
-                    <i class="bi bi-caret-right-fill" aria-hidden="true"></i>
-                </a>
-            </li>
-        </ul>
-    </nav>
+    {% with extra_class="mt-auto py-3" %}
+        {% include "_pagination.html" %}
+    {% endwith %}
 </section>
 
 <script src="/static/js/search_filter.js"></script>

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -34,56 +34,27 @@
         
         <!-- Filter Panel -->
         <div id="filter-panel" class="card bg-secondary-subtle p-3 mt-2" style="display: none;">
-  <!-- explanation of the generic risk-assessment process flow -->
-  <div class="">
-    <h3><span class="text-vhpblue" id="collection-name">Safety Assessment Workflow Steps</span></h3>
-    <p class="mb-4">The Virtual Human Platform implements a generic safety assessment as a five-step process. For more information regarding the Safety Assessment Workflow, visit our <a class="link-vhpblue text-decoration-none" href="{{ url_for('SafetyAssessmentWorkflow') }}" >Safety Assessment Workflow info page.</a> <p>
-    </p>
-  </div>
-  <div class="row row-cols-1 row-cols-md-6 gap-2 mx-auto">
-    <button class="btn btn-primary btn-vhpblue card-button-vhpblue" type="submit"
-      data-bs-toggle="tooltip" data-bs-placement="top" title="Chemical characteristics and Hazard Identification is a Safety Assessment Workflow Step that categorizes services that use molecular structures, chemical descriptors, and databases to predict or analyze the properties, behavior, and potential risks of chemical substances.">
-      Chemical Characteristics and Hazard Identification</button>
-    <button class="btn btn-primary btn-vhpblue card-button-vhpblue" type="submit"
-      data-bs-toggle="tooltip" data-bs-placement="top" title="Exposure is a Safety Assessment Workflow Step which categorizes services that evaluate and analyze the route, duration, magnitude and frequency of exposure of an organism or (sub)population to one or multiple chemicals.">
-      Exposure</button>
-    <button class="btn btn-primary btn-vhpblue card-button-vhpblue" type="submit"
-      data-bs-toggle="tooltip" data-bs-placement="top" title="Toxicokinetics is a Safety Assessment Workflow Step which categorizes services that analyze the kinetics (absorption, distribution, metabolism and excretion) of chemicals and how these processes influence the internal dose.">
-      Toxicokinetics</button>
-    <button class="btn btn-primary btn-vhpblue card-button-vhpblue" type="submit"
-      data-bs-toggle="tooltip" data-bs-placement="top" title="Toxicodynamics is a Safety Assessment Workflow Step which categorizes services that use or extend the (quantitative) AOP framework to analyze and assess the interaction of chemicals with biological targets.">
-      Toxicodynamics</button>
-    <button class="btn btn-primary btn-vhpblue card-button-vhpblue" type="submit"
-      data-bs-toggle="tooltip" data-bs-placement="top" title="Adverse Outcome is a Safety Assessment Workflow Step which specifically refers to clinical and epidemiological effects. It categorizes services that provide information on the toxicological endpoints and adverse outcomes at a clinical or epidemiological level of chemical exposures.">
-      Adverse Outcome</button>
-  </div>
-  <div class=""><p>&nbsp;</p></div> <!-- how to do this properly?? -->
-
             <div class="gap-2 pb-1">
-                <!-- Flow Step Dropdown -->
-                <div class="btn-group mb-1">
-                    <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
-                        Safety Assessment Workflow Step
-                    </button>
-                    <ul class="dropdown-menu">
-                        {% for stage in stages %}
-                        <li><a class="dropdown-item " href="#" data-filter-type="flow-step" data-filter-value="{{ stage }}"{% if stage in stage_explanations %} data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations[stage] }}"{% endif %}>
-                            {{ stage }}{% if stage in stage_explanations %} <i class="text-vhpblue bi bi-question-circle"></i>{% endif %}
-                        </a></li>
-                        {% endfor %}
-                    </ul>
-                </div>
-                
                 <!-- Regulatory Questions Dropdown -->
                 <div class="btn-group mb-1">
-                    <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
+                    <button class="btn btn-sm btn-vhppink-distinct dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
                         Regulatory Question
                     </button>
                     <ul class="dropdown-menu">
                         {% for question in reg_questions.keys() %}
-                        <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="{{ question }}" data-applies-to-case-slug="{{ reg_question_cases.get(question, '') }}"{% if question in reg_question_explanations %} data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations[question] }}"{% endif %}>
-                            {{ question }}{% if question in reg_question_explanations %} <i class="text-vhpblue bi bi-question-circle"></i>{% endif %}
-                        </a></li>
+                          <li><a class="dropdown-item" href="#" data-filter-type="reg-question" data-filter-value="{{ question }}" data-applies-to-case-slug="{{ reg_question_cases.get(question, '') }}"{% if question in reg_question_explanations %} data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ reg_question_explanations[question] }}"{% endif %}>{{ question }}{% if question in reg_question_explanations %} <i class="bi bi-question-circle text-vhpblue"></i>{% endif %}</a></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+
+                <!-- Flow Step Dropdown -->
+                <div class="btn-group mb-1">
+                    <button class="btn btn-sm btn-vhppurple dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false">
+                        Flow Step
+                    </button>
+                    <ul class="dropdown-menu">
+                        {% for stage in stages %}
+                          <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="{{ stage }}"{% if stage in stage_explanations %} data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations[stage] }}"{% endif %}>{{ stage }}{% if stage in stage_explanations %} <i class="bi bi-question-circle text-vhpblue"></i>{% endif %}</a></li>
                         {% endfor %}
                     </ul>
                 </div>


### PR DESCRIPTION
This pull request refactors how case studies and regulatory questions are loaded and filtered throughout the application, moving from hardcoded lists to dynamic fetching from a remote configuration. It also unifies and improves filter logic for case studies, regulatory questions, and workflow stages across tools, methods, and data endpoints, supporting multi-select filters and consistent OR/AND semantics. The main template contexts are updated to use the new dynamic data, and code duplication is reduced by centralizing logic.

**Dynamic case study and regulatory question loading:**
- Removed hardcoded `CASESTUDIES` and `REG_QUESTIONS` in `app.py`, replacing them with functions that fetch case studies and regulatory questions from a remote JSON-LD config (`get_casestudies`, `get_reg_questions`, etc.), making the app more maintainable and up-to-date with upstream changes. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L31-L32) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L61-R62) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R143-R232)

**Filter logic improvements and unification:**
- Refactored filter handling for case studies, regulatory questions, and flow steps to support multi-select (OR within field, AND across fields) and consistent behavior across tools, methods, and data endpoints. Updated the `_apply_filters` method in `data/biostudies/search.py` for the same semantics. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L594-R674) [[2]](diffhunk://#diff-b0744833988c8f43c0b970b080d4ef1189d4156a36ac28a1cc6ab84da4af083cL491-L512)

**Template and context updates:**
- Updated all relevant Flask route handlers to pass dynamic lists of case studies, regulatory questions, and their explanations to templates, removing reliance on static variables. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L667-R736) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L797-R869) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R1024-R1030) [[4]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R1176-R1182)

**Workflow stage normalization:**
- Improved workflow stage handling in methods and tools views by resolving glossary URIs to human-readable labels and ensuring dropdowns remain stable regardless of filtering, enhancing UX and data consistency. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R900-R951) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L954-R1064)

**Routing and sitemap updates:**
- Updated routes and sitemap generation to use the dynamic case study list, ensuring new case studies are automatically included. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L554-R619) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L1196-R1323)


<table>
<tr>
<td>Before
</td>
<td>After
</td>
</tr>
<tr>
<td>
<img width="2940" height="1664" alt="image" src="https://github.com/user-attachments/assets/1c1160e1-aecd-4ef9-8576-55beec4df38a" />
</td><td>
<img width="2940" height="1662" alt="image" src="https://github.com/user-attachments/assets/87a404ee-4032-484c-8c1e-a82c857b5628" />
</td>
</tr>
<tr>
<td>
<img width="2940" height="1662" alt="image" src="https://github.com/user-attachments/assets/3dcf9aad-7d5e-4d6d-86c4-3f892e6ca0a4" />
</td><td>
<img width="2940" height="1660" alt="image" src="https://github.com/user-attachments/assets/3c988aa7-0fcf-4569-91bb-2878995af0ee" />
</td>
</tr>
<tr>
<td>
<img width="2940" height="1656" alt="image" src="https://github.com/user-attachments/assets/7255b526-c3cb-4a80-93f9-be126f5c04ec" />
</td><td>
<img width="2940" height="1660" alt="image" src="https://github.com/user-attachments/assets/64826f44-c3ae-477e-a423-e530d46b05cf" />
</td>
</tr>
</table>