### PR TITLE
added the VHP icons conditionally to the individual tool pages

### DIFF
--- a/static/css/tools.css
+++ b/static/css/tools.css
@@ -47,8 +47,8 @@
 }
 
 .vhp-badge {
-  width: 32px;
   height: 32px;
+  width: auto;
   padding: 4px;
   background-color: var(--bs-tertiary-bg);
   border: 1px solid var(--bs-border-color);
@@ -56,7 +56,7 @@
   filter: none !important;
   opacity: 1 !important;
   flex-shrink: 0;
-  box-sizing: border-box;
+  box-sizing: content-box;
 }
 
 

--- a/templates/tools/tool.html
+++ b/templates/tools/tool.html
@@ -25,10 +25,18 @@
 
 <section class="container py-5">
     <div class="pb-2">
-        <h1><span class="text-vhpblue" id="collection-name">{{ tool_json.service }}</span></h1>
-
+        <h1><span class="text-vhpblue" id="collection-name">{{ tool_json.service }}
+        {% if tool_details.instance.url != "no_url" %}
+            <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_HexaHead_300.png" alt="Developed by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Developed by VHP" height="45px">
+            {% if tool_details.instance.get("vhp-platform") == "Development" %}
+                <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP" height="45px">
+            {% elif tool_details.instance.get("vhp-platform") == "development" %}
+                <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP" height="45px">
+            {% endif %}
+        {% endif %}
+        </span></h1>
     </div>
-    
+
 <div class="card">
   <div class="card-header">
     <ul class="nav nav-tabs card-header-tabs" role="tablist">

--- a/templates/tools/tool.html
+++ b/templates/tools/tool.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<link rel="stylesheet" href="/static/css/casestudies.css" />
+<link rel="stylesheet" href="{{ url_for('static', filename='css/tools.css') }}">
 <link rel="stylesheet" property="stylesheet" href="https://elixirtess.github.io/TeSS_widgets/css/tess-widget.css"/>
 
 <!-- Bioschemas / schema.org annotation -->
@@ -23,15 +23,15 @@
 </script>
 
 
-<section class="container py-5">
+<section class="container py-md-5 py-3 d-flex flex-column min-vh-100">
     <div class="pb-2">
         <h1><span class="text-vhpblue" id="collection-name">{{ tool_json.service }}
         {% if tool_details.instance.url != "no_url" %}
-            <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_HexaHead_300.png" alt="Developed by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Developed by VHP" height="45px">
+            <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_HexaHead_300.png" alt="Developed by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Developed by VHP">
             {% if tool_details.instance.get("vhp-platform") == "Development" %}
-                <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP" height="45px">
+                <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP">
             {% elif tool_details.instance.get("vhp-platform") == "development" %}
-                <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP" height="45px">
+                <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP">
             {% endif %}
         {% endif %}
         </span></h1>

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -117,15 +117,14 @@
                     {% endif %}
                     </div>
                     <div class="card-body">
-                        <div class="d-flex align-items-center gap-2">
-                            <h2 class="card-title mb-0">{{ item.service }}</h2>
+                        <h2 class="card-title mb-0">{{ item.service }}
                             {% if item.inst_url != "no_url" %}
-                                <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_HexaHead_300.png" alt="Developed by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Developed by VHP">
+                                <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_HexaHead_300.png" alt="Developed by VHP" class="vhp-badge ms-1" data-bs-toggle="tooltip" data-bs-title="Developed by VHP">
                                 {% if item.vhp_hosted %}
-                                    <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP">
+                                    <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge ms-1" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP">
                                 {% endif %}
                             {% endif %}
-                        </div>
+                        </h2>
                         <p id="desc" class="card-text">{{ item.description }}</p>
                     </div>
                     <div class="card-footer bg-white border-0 py-3">


### PR DESCRIPTION
Added the VHP icons to indicated `developed by` and `hosted by` on the individual tool pages too. It adds them after the name of the tool, here at the top:

<img width="926" height="554" alt="image" src="https://github.com/user-attachments/assets/c458dc1d-61b5-4130-8fb2-fc4942f9fec7" />

See also https://github.com/VHP4Safety/virtual-human-platform/issues/417

(And yes, it has the old flow step names :/ )