### PR TITLE
Match case study headline color to its process-flow step icon

### DIFF
--- a/static/js/casestudies.js
+++ b/static/js/casestudies.js
@@ -38,6 +38,20 @@ function stepTypeToColor(type) {
   return baseclass + " " + color
 }
 
+// Headline accent color per step — matches the process-flow icon colors
+// defined in casestudies.css (.step-item[data-step="N"] .step-icon).
+function stepHeadingClass(stepNumber) {
+  const map = {
+    1: "text-vhppink-distinct",
+    2: "text-vhpdarkpurple",
+    3: "text-vhpdarkteal",
+    4: "text-vhplightteal",
+    5: "text-vhpblue",
+    6: "text-vhplightteal",
+  };
+  return map[stepNumber] || "text-vhppink-distinct";
+}
+
 function stepAction(step, onClickFn) {
   if (step.type && step.type == "tool") {
     if (step.id) {
@@ -84,7 +98,7 @@ function renderStepButtons(steps, btnClass, onClickFn) {
 function updateStep1Content() {
   if (!contentLoaded) return;
   document.getElementById("step1-content").innerHTML =
-    `<h1 class="text-vhppink-distinct">${step1Contents.navTitle}</h1><p class="text-secondary fs-5">${step1Contents.navDescription}</p>` +
+    `<h1 class="${stepHeadingClass(1)}">${step1Contents.navTitle}</h1><p class="text-secondary fs-5">${step1Contents.navDescription}</p>` +
     renderStepButtons(step1Contents.questions, "step1", "selectStep1");
   document.getElementById("step1-bottom-content").innerHTML =
     buildAccordionHTML(step1Contents.content);
@@ -94,7 +108,7 @@ function updateStep2Content() {
   if (!step2Contents[currentStep1Value]) return;
   const nav = step2Contents[currentStep1Value];
   document.getElementById("step2-content").innerHTML =
-  `<h1 class="text-vhppink-distinct">${nav.navTitle}</h1>
+  `<h1 class="${stepHeadingClass(2)}">${nav.navTitle}</h1>
    <p class="text-secondary fs-5">${nav.navDescription}</p>` +
     (nav.image ? nav.image : "") +             
   renderStepButtons(nav.steps, "step2", "selectStep2");
@@ -107,11 +121,11 @@ function updateStep3Content() {
   if (!step3Contents[currentStep1Value][currentStep2Value]) return;
   if (step.steps) {
     document.getElementById("step3-content").innerHTML =
-      `<h1 class="text-vhppink-distinct"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
+      `<h1 class="${stepHeadingClass(3)}"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
       renderStepButtons(step.steps, "step3", "selectStep3");
   } else if (step.tools) {
     document.getElementById("step3-content").innerHTML =
-      `<h1 class="text-vhppink-distinct"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
+      `<h1 class="${stepHeadingClass(3)}"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
       renderStepButtons(step.tools, "step3", null);
   }
   document.getElementById("step3-bottom-content").innerHTML = buildAccordionHTML(step.content);
@@ -125,15 +139,15 @@ function updateStep4Content() {
   const step = step4Contents[currentStep1Value][currentStep2Value][currentStep3Value];
   if (step.tools) {
     document.getElementById("step4-content").innerHTML =
-      `<h1 class="text-vhppink-distinct"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
+      `<h1 class="${stepHeadingClass(4)}"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
       renderStepButtons(step.tools, "step4", null);
   } else if (step.steps) {
     document.getElementById("step4-content").innerHTML =
-      `<h1 class="text-vhppink-distinct"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
+      `<h1 class="${stepHeadingClass(4)}"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
       renderStepButtons(step.steps, "step4", "selectStep4");
   } else {
     document.getElementById("step4-content").innerHTML =
-      `<h1 class="text-vhppink-distinct"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>`;
+      `<h1 class="${stepHeadingClass(4)}"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>`;
   }
   document.getElementById("step4-bottom-content").innerHTML = buildAccordionHTML(step.content);
 }
@@ -147,15 +161,15 @@ function updateStep5Content() {
   const step = step5Contents[currentStep1Value][currentStep2Value][currentStep3Value][currentStep4Value];
   if (step.tools) {
     document.getElementById("step5-content").innerHTML =
-      `<h1 class="text-vhppink-distinct"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
+      `<h1 class="${stepHeadingClass(5)}"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
       renderStepButtons(step.tools, "step5", null);
   } else if (step.steps) {
     document.getElementById("step5-content").innerHTML =
-      `<h1 class="text-vhppink-distinct"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
+      `<h1 class="${stepHeadingClass(5)}"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
       renderStepButtons(step.steps, "step5", "selectStep5");
   } else {
     document.getElementById("step5-content").innerHTML =
-      `<h1 class="text-vhppink-distinct"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>`;
+      `<h1 class="${stepHeadingClass(5)}"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>`;
   }
   document.getElementById("step5-bottom-content").innerHTML = buildAccordionHTML(step.content);
 }
@@ -170,15 +184,15 @@ function updateStep6Content() {
   const step = step6Contents[currentStep1Value][currentStep2Value][currentStep3Value][currentStep4Value][currentStep5Value];
   if (step.tools) {
     document.getElementById("step6-content").innerHTML =
-      `<h1 class="text-vhppink-distinct"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
+      `<h1 class="${stepHeadingClass(6)}"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
       renderStepButtons(step.tools, "step6", null);
   } else if (step.steps) {
     document.getElementById("step6-content").innerHTML =
-      `<h1 class="text-vhppink-distinct"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
+      `<h1 class="${stepHeadingClass(6)}"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>` +
       renderStepButtons(step.steps);
   } else {
     document.getElementById("step6-content").innerHTML =
-      `<h1 class="text-vhppink-distinct"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>`;
+      `<h1 class="${stepHeadingClass(6)}"><span class='kinetics-bold'>${step.navTitle}</span></h1><p class='step-desc text-secondary fs-5'>${step.navDescription}</p>`;
   }
   document.getElementById("step6-bottom-content").innerHTML = buildAccordionHTML(step.content);
 }


### PR DESCRIPTION
## Summary

On an individual case study page, every step headline (`h1`) was hardcoded to pink (`text-vhppink-distinct`), so only step 1 happened to match its Process Flow icon. Now each sliding panel's headline uses the **same VHP accent color as that step's icon** in the Process Flow header.

## Changes

- `static/js/casestudies.js`: added a `stepHeadingClass(stepNumber)` helper (mirrors the existing `stepTypeToColor`) and routed all 13 headline renders through it across `updateStep1Content`…`updateStep6Content`.

| Panel | Icon | Headline class |
|-------|------|----------------|
| 1 | Regulatory Question | `text-vhppink-distinct` (unchanged) |
| 2 | Workflow Step | `text-vhpdarkpurple` |
| 3 | Case Study Step | `text-vhpdarkteal` |
| 4 | Case Study Substep | `text-vhplightteal` |
| 5 | Tools, Models & Data | `text-vhpblue` |
| 6 | *(no icon)* | `text-vhplightteal` (reuses step 4) |

Each `text-*` utility resolves to the same `--bs-vhp*` variable the icon background uses (`casestudies.css`), so headlines and icons stay in sync with no duplicated color values. The breadcrumb active item and feedback button intentionally stay pink.

## Verification

Open e.g. `/casestudies/thyroid` and drill through the steps — each panel's `h1` should match the highlighted Process Flow icon (pink → dark purple → dark teal → light teal → blue → light teal). Confirm too on a deep-linked URL + refresh, since headlines re-render on `DOMContentLoaded`/`popstate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)