### PR TITLE
[feat] the developed-by-VHP info from the JSON is now used

### DIFF
--- a/app.py
+++ b/app.py
@@ -1085,12 +1085,17 @@ def tools():
             # Fetch per-tool detail JSON to check hosting status
             tool_id = tool.get("id", "")
             vhp_hosted = False
-            if inst_url != "no_url" and tool_id:
+            vhp_deved = False
+            if tool_id:
                 detail = get_service_detail(tool_id)
-                vhp_platform = (
-                    detail.get("instance", {}).get("vhp-platform", "").lower()
-                )
-                vhp_hosted = vhp_platform not in ("external", "independent", "")
+                if detail.get("developed-by-VHP"):
+                    vhp_deved = detail.get("developed-by-VHP") not in ("false")
+                if inst_url != "no_url":
+                    vhp_platform = (
+                        detail.get("instance", {}).get("vhp-platform", "").lower()
+                    )
+                    vhp_hosted = vhp_platform not in ("external", "independent", "")
+            tool["vhp_deved"] = vhp_deved
             tool["vhp_hosted"] = vhp_hosted
 
         return render_template(

--- a/app.py
+++ b/app.py
@@ -1089,7 +1089,7 @@ def tools():
             if tool_id:
                 detail = get_service_detail(tool_id)
                 if detail.get("developed-by-VHP"):
-                    vhp_deved = detail.get("developed-by-VHP") not in ("false")
+                    vhp_deved = detail.get("developed-by-VHP") == "true"
                 if inst_url != "no_url":
                     vhp_platform = (
                         detail.get("instance", {}).get("vhp-platform", "").lower()

--- a/templates/tools/tool.html
+++ b/templates/tools/tool.html
@@ -26,13 +26,13 @@
 <section class="container py-md-5 py-3 d-flex flex-column min-vh-100">
     <div class="pb-2">
         <h1><span class="text-vhpblue" id="collection-name">{{ tool_json.service }}
-        {% if tool_details.instance.url != "no_url" %}
+        {% if tool_details.get("developed-by-VHP") != "false" %}
             <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_HexaHead_300.png" alt="Developed by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Developed by VHP">
-            {% if tool_details.instance.get("vhp-platform") == "Development" %}
-                <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP">
-            {% elif tool_details.instance.get("vhp-platform") == "development" %}
-                <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP">
-            {% endif %}
+        {% endif %}
+        {% if tool_details.instance.get("vhp-platform") == "Development" %}
+            <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP">
+        {% elif tool_details.instance.get("vhp-platform") == "development" %}
+            <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP">
         {% endif %}
         </span></h1>
     </div>

--- a/templates/tools/tool.html
+++ b/templates/tools/tool.html
@@ -29,9 +29,9 @@
         {% if tool_details.get("developed-by-VHP") != "false" %}
             <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_HexaHead_300.png" alt="Developed by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Developed by VHP">
         {% endif %}
-        {% if tool_details.instance.get("vhp-platform") == "Development" %}
+        {% if tool_details.instance and tool_details.instance.get("vhp-platform") == "Development" %}
             <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP">
-        {% elif tool_details.instance.get("vhp-platform") == "development" %}
+        {% elif tool_details.instance and tool_details.instance.get("vhp-platform") == "development" %}
             <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP">
         {% endif %}
         </span></h1>

--- a/templates/tools/tool.html
+++ b/templates/tools/tool.html
@@ -26,7 +26,7 @@
 <section class="container py-md-5 py-3 d-flex flex-column min-vh-100">
     <div class="pb-2">
         <h1><span class="text-vhpblue" id="collection-name">{{ tool_json.service }}
-        {% if tool_details.get("developed-by-VHP") != "false" %}
+        {% if tool_details.get("developed-by-VHP") == "true" %}
             <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_HexaHead_300.png" alt="Developed by VHP" class="vhp-badge" data-bs-toggle="tooltip" data-bs-title="Developed by VHP">
         {% endif %}
         {% if tool_details.instance and tool_details.instance.get("vhp-platform") == "Development" %}

--- a/templates/tools/tools.html
+++ b/templates/tools/tools.html
@@ -118,8 +118,10 @@
                     </div>
                     <div class="card-body">
                         <h2 class="card-title mb-0">{{ item.service }}
-                            {% if item.inst_url != "no_url" %}
+                            {% if item.vhp_deved %}
                                 <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_HexaHead_300.png" alt="Developed by VHP" class="vhp-badge ms-1" data-bs-toggle="tooltip" data-bs-title="Developed by VHP">
+                            {% endif %}
+                            {% if item.inst_url != "no_url" %}
                                 {% if item.vhp_hosted %}
                                     <img src="/static/images/logos/icon/PNG/300ppi/VHP_Icon_Head_300.png" alt="Hosted by VHP" class="vhp-badge ms-1" data-bs-toggle="tooltip" data-bs-title="Hosted by VHP">
                                 {% endif %}


### PR DESCRIPTION
Now used the new info added in [this PR](https://github.com/VHP4Safety/cloud/pull/297) to properly annotated tools with "developed by VHP".

Implements: https://github.com/VHP4Safety/virtual-human-platform/issues/422

Before:

<img width="406" height="356" alt="image" src="https://github.com/user-attachments/assets/0178515d-0890-4d7c-b988-810bf59f217a" />

After:

<img width="440" height="384" alt="image" src="https://github.com/user-attachments/assets/b1fbb929-26ac-464a-ba9c-103a36330b75" />
