### PR TITLE
Jh data tab fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -731,14 +731,15 @@ def data():
     # Get query parameters for pagination and search
     page = request.args.get("page", 1, type=int)
     page_size = request.args.get("page_size", 6, type=int)
-    search_query = request.args.get("query", "", type=str)
+    search_query = request.args.get("search", "", type=str)
 
-    # Get filter parameters (multi-select via repeated query params, matching
-    # tools/methods). Each filter type is a list; the extractor groups by
-    # field and applies OR-within-field, AND-across-fields.
-    filter_case_study = request.args.getlist("filter_case_study")
-    filter_regulatory_question = request.args.getlist("filter_regulatory_question")
-    filter_flow_step = request.args.getlist("filter_flow_step")
+    # Get filter parameters (multi-select via repeated query params). Param
+    # names match tools/methods: ?case_study=, ?reg_q=, ?stage=, ?search=.
+    # Each filter type is a list; the extractor groups by field and applies
+    # OR-within-field, AND-across-fields.
+    filter_case_study = request.args.getlist("case_study")
+    filter_regulatory_question = request.args.getlist("reg_q")
+    filter_flow_step = request.args.getlist("stage")
 
     # Build filter list (one tuple per (field, value)); repeated field names
     # become OR within that field downstream in _apply_filters.

--- a/app.py
+++ b/app.py
@@ -742,11 +742,14 @@ def data():
 
     # Build filter list (one tuple per (field, value)); repeated field names
     # become OR within that field downstream in _apply_filters.
+    # The reg-question dropdown sends the question label; records store the
+    # canonical reg_q_Xy key, so convert label -> key (same map methods uses).
+    reg_q_label_to_key = {v["label"]: k for k, v in get_reg_questions().items()}
     filters = []
     for v in filter_case_study:
         filters.append(("case_study", v))
     for v in filter_regulatory_question:
-        filters.append(("regulatory_question", v))
+        filters.append(("regulatory_question", reg_q_label_to_key.get(v, v)))
     for v in filter_flow_step:
         filters.append(("flow_step", v))
 
@@ -810,6 +813,8 @@ def data():
         reg_question_explanations=get_reg_question_explanations(),
         reg_question_cases={v["label"]: v.get("case", "") for v in get_reg_questions().values()},
         reg_questions={v["label"]: k for k, v in get_reg_questions().items()},
+        reg_q_labels={k: v["label"] for k, v in get_reg_questions().items()},
+        process_flow_steps=get_process_flow_steps(),
         case_studies=list(get_casestudies()),
     )
 
@@ -859,10 +864,17 @@ def data_detail(dataid):
     elif zen_error and not bs_error:
         if bs_total != 1:
             return abort(404)
+    # reg-question records store the canonical reg_q_Xy key; map key -> label so
+    # the badges show the human-readable question.
+    reg_q_labels = {k: v["label"] for k, v in get_reg_questions().items()}
     if studies:
-        return render_template("data/data_details.html", data=studies[0])
+        return render_template(
+            "data/data_details.html", data=studies[0], reg_q_labels=reg_q_labels
+        )
     elif datasets:
-        return render_template("data/data_details.html", data=datasets[0])
+        return render_template(
+            "data/data_details.html", data=datasets[0], reg_q_labels=reg_q_labels
+        )
     return abort(404)
 
 

--- a/data/biostudies/search.py
+++ b/data/biostudies/search.py
@@ -504,13 +504,22 @@ class BioStudiesExtractor:
         for field, value in filters:
             accepted_by_field.setdefault(field, []).append(str(value).strip().lower())
 
+        def _field_values(metadata: dict, field: str) -> list[str]:
+            # A field may be a list (case_study/regulatory_question/flow_step)
+            # or a plain string; normalise to a lowercased list for matching.
+            raw = metadata.get(field, "")
+            values = raw if isinstance(raw, (list, tuple)) else [raw]
+            return [str(v).strip().lower() for v in values if v]
+
         filtered = []
         for hit in hits:
             metadata = hit.get("metadata", {})
             if not metadata:
                 continue
+            # AND across fields; within a field the record matches if any of its
+            # values is among the accepted ones (OR).
             if all(
-                str(metadata.get(field, "")).strip().lower() in accepted
+                any(v in accepted for v in _field_values(metadata, field))
                 for field, accepted in accepted_by_field.items()
             ):
                 filtered.append(hit)
@@ -593,10 +602,11 @@ class BioStudiesExtractor:
                 ),
                 "modification_date": raw_data.get("mdate", "N/A"),
                 "type": raw_data.get("type", "N/A"),
-                # VHP4Safety filterable fields
-                "case_study": "",
-                "regulatory_question": "",
-                "flow_step": "",
+                # VHP4Safety filterable fields (a record may carry several of
+                # each, so these are lists)
+                "case_study": [],
+                "regulatory_question": [],
+                "flow_step": [],
                 "collection": "",
                 "attributes": [],
                 "authors": [],
@@ -620,14 +630,18 @@ class BioStudiesExtractor:
                 return "" if v is None else str(v)
 
             def _capture_vhp_fields(attr_name: str, attr_value: str):
+                # case study / regulatory question / process flow step can each
+                # appear multiple times in a submission; collect all (deduped,
+                # order-preserving).
+                field = {
+                    "case study": "case_study",
+                    "regulatory question": "regulatory_question",
+                    "process flow step": "flow_step",
+                }.get(attr_name)
                 if attr_name == "attachto":
                     metadata["collection"] = attr_value
-                elif attr_name == "case study":
-                    metadata["case_study"] = attr_value
-                elif attr_name == "regulatory question":
-                    metadata["regulatory_question"] = attr_value
-                elif attr_name == "process flow step":
-                    metadata["flow_step"] = attr_value
+                elif field and attr_value and attr_value not in metadata[field]:
+                    metadata[field].append(attr_value)
 
             BIO_KEYS = {
                 "organism",

--- a/static/css/data.css
+++ b/static/css/data.css
@@ -102,6 +102,17 @@
 }
 
 
+/* Hide scrollbar while keeping scroll/swipe (e.g. one-line pill strips) */
+.scrollbar-none {
+  -ms-overflow-style: none;   /* IE / old Edge */
+  scrollbar-width: none;      /* Firefox */
+}
+
+.scrollbar-none::-webkit-scrollbar {
+  display: none;              /* Chrome, Safari, Edge */
+}
+
+
 /* Mobile phone screens ≤ 375px */
 @media (max-width: 408px) {
 

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -55,13 +55,9 @@
                         Flow Step
                     </button>
                     <ul class="dropdown-menu">
-                        <li><a class="dropdown-item text-wrap text-md-nowrap" href="#" data-filter-type="flow-step" data-filter-value="ADME" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['ADME'] }}">ADME <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item text-wrap text-md-nowrap" href="#" data-filter-type="flow-step" data-filter-value="Chemical Information" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Chemical Information'] }}">Chemical Information <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item text-wrap text-md-nowrap" href="#" data-filter-type="flow-step" data-filter-value="General" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['General'] }}">General <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item text-wrap text-md-nowrap" href="#" data-filter-type="flow-step" data-filter-value="Hazard Assessment" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Hazard Assessment'] }}">Hazard Assessment <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item text-wrap text-md-nowrap" href="#" data-filter-type="flow-step" data-filter-value="External exposure" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['External exposure'] }}">External exposure <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item text-wrap text-md-nowrap" href="#" data-filter-type="flow-step" data-filter-value="Generic" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Generic'] }}">Generic <i class="bi bi-question-circle text-vhpblue"></i></a></li>
-                        <li><a class="dropdown-item text-wrap text-md-nowrap" href="#" data-filter-type="flow-step" data-filter-value="Other" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ stage_explanations['Other'] }}">Other <i class="bi bi-question-circle text-vhpblue"></i></a></li>
+                        {% for step in process_flow_steps.values() %}
+                        <li><a class="dropdown-item" href="#" data-filter-type="flow-step" data-filter-value="{{ step.label }}"{% if step.description %} data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ step.description }}"{% endif %}>{{ step.label }}{% if step.description %} <i class="bi bi-question-circle text-vhpblue"></i>{% endif %}</a></li>
+                        {% endfor %}
                     </ul>
                 </div>
             </div>
@@ -111,9 +107,9 @@
                     </div>
                     <div class = "card-header bg-white align-items-center">
                             {% set cs0 = study.metadata.case_study[0] if study.metadata.case_study else '' %}
-                            {% set rq0 = study.metadata.regulatory_question[0] if study.metadata.regulatory_question else '' %}
+                            {% set rq0 = reg_q_labels.get(study.metadata.regulatory_question[0], study.metadata.regulatory_question[0]) if study.metadata.regulatory_question else '' %}
                             {% for cs in study.metadata.case_study %}<a role="button" href="{{url_for('casestudy', case=cs|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">{{cs|capitalize }}</a> {% endfor %}
-                            {% for rq in study.metadata.regulatory_question %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=rq )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">{{rq}}</a> {% endfor %}
+                            {% for rq in study.metadata.regulatory_question %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=reg_q_labels.get(rq, rq) )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">{{ reg_q_labels.get(rq, rq) }}</a> {% endfor %}
                             {% for fs in study.metadata.flow_step %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=rq0, step=fs )}}"  style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppurple rounded-pill border border-vhppurple d-inline-flex align-items-center text-wrap">{{fs}}</a> {% endfor %}
                     </div>
                     <div class="card-body">

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -11,7 +11,7 @@
 
     <nav class="navbar navbar-expand-lg d-inline">
         <form method="GET" action="{{ url_for('data') }}" class="d-flex" role="search" id="search-form">
-            <input type="text" class="form-control me-2" name="query" id="search-input" value="{{ search_query or '' }}" placeholder="Search for datasets (e.g., S-ONTX26, toxicity, liver...)" />
+            <input type="text" class="form-control me-2" name="search" id="search-input" value="{{ search_query or '' }}" placeholder="Search for datasets (e.g., S-VHPS28, dinoseb, liver...)" />
             <!-- Filter hidden inputs are added dynamically by search_filter.js
                  in multipleInputs mode (one <input> per selected value). -->
             <div class="btn-group" role="group" aria-label="Search and filter buttons">
@@ -214,9 +214,9 @@
                 'reg-question': [{% for q in filter_regulatory_question %}'{{ q }}'{% if not loop.last %}, {% endif %}{% endfor %}]
             },
             filterFieldMap: {
-                'case-study': 'filter_case_study',
-                'flow-step': 'filter_flow_step',
-                'reg-question': 'filter_regulatory_question'
+                'case-study': 'case_study',
+                'flow-step': 'stage',
+                'reg-question': 'reg_q'
             },
             filterLabels: {
                 'case-study': 'Case Study',

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -110,9 +110,11 @@
                         <span class="badge bg-vhplight-blue text-secondary rounded-pill align-content-center">{{ study.type or 'unknown' }}</span>
                     </div>
                     <div class = "card-header bg-white align-items-center">
-                            {% if study.metadata.case_study%}<a role="button" href="{{url_for('casestudy', case=study.metadata.case_study|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">Case Study: {{study.metadata.case_study|capitalize }}</a>{%endif%}
-                            {% if study.metadata.regulatory_question%}<a role="button" href="{{url_for('casestudy', case=study.metadata.case_study|lower, question=study.metadata.regulatory_question )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">Regulatory Question: {{study.metadata.regulatory_question}}</a>{%endif%}
-                            {% if study.metadata.flow_step%}<a role="button" href="{{url_for('casestudy', case=study.metadata.case_study|lower, question=study.metadata.regulatory_question, step=study.metadata.flow_step )}}"  style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppurple rounded-pill border border-vhppurple d-inline-flex align-items-center text-wrap">Flow Step: {{study.metadata.flow_step}}</a>{%endif%}
+                            {% set cs0 = study.metadata.case_study[0] if study.metadata.case_study else '' %}
+                            {% set rq0 = study.metadata.regulatory_question[0] if study.metadata.regulatory_question else '' %}
+                            {% for cs in study.metadata.case_study %}<a role="button" href="{{url_for('casestudy', case=cs|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">{{cs|capitalize }}</a> {% endfor %}
+                            {% for rq in study.metadata.regulatory_question %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=rq )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">{{rq}}</a> {% endfor %}
+                            {% for fs in study.metadata.flow_step %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=rq0, step=fs )}}"  style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppurple rounded-pill border border-vhppurple d-inline-flex align-items-center text-wrap">{{fs}}</a> {% endfor %}
                     </div>
                     <div class="card-body">
                         <h5 class="card-title" style="word-break: break-word;">

--- a/templates/data/data.html
+++ b/templates/data/data.html
@@ -105,19 +105,26 @@
                         <span class="result-accession">{{ study.accession or study.accno }}</span>
                         <span class="badge bg-vhplight-blue text-secondary rounded-pill align-content-center">{{ study.type or 'unknown' }}</span>
                     </div>
-                    <div class = "card-header bg-white align-items-center">
-                            {% set cs0 = study.metadata.case_study[0] if study.metadata.case_study else '' %}
-                            {% set rq0 = reg_q_labels.get(study.metadata.regulatory_question[0], study.metadata.regulatory_question[0]) if study.metadata.regulatory_question else '' %}
-                            {% for cs in study.metadata.case_study %}<a role="button" href="{{url_for('casestudy', case=cs|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">{{cs|capitalize }}</a> {% endfor %}
-                            {% for rq in study.metadata.regulatory_question %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=reg_q_labels.get(rq, rq) )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">{{ reg_q_labels.get(rq, rq) }}</a> {% endfor %}
-                            {% for fs in study.metadata.flow_step %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=rq0, step=fs )}}"  style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppurple rounded-pill border border-vhppurple d-inline-flex align-items-center text-wrap">{{fs}}</a> {% endfor %}
+                    <div class="card-header bg-white">
+                        <div class="position-relative">
+                            <div class="d-flex flex-nowrap overflow-x-auto gap-1 scrollbar-none pill-scroll">
+                                {% set cs0 = study.metadata.case_study[0] if study.metadata.case_study else '' %}
+                                {% set rq0 = reg_q_labels.get(study.metadata.regulatory_question[0], study.metadata.regulatory_question[0]) if study.metadata.regulatory_question else '' %}
+                                {% for cs in study.metadata.case_study %}<a role="button" href="{{url_for('casestudy', case=cs|lower)}}" style="font-size:0.75em;" class="flex-shrink-0 lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-nowrap">{{cs|capitalize }}</a>{% endfor %}
+                                {% for rq in study.metadata.regulatory_question %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=reg_q_labels.get(rq, rq) )}}" style="font-size:0.75em;" class="flex-shrink-0 lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-nowrap">{{ reg_q_labels.get(rq, rq) }}</a>{% endfor %}
+                                {% for fs in study.metadata.flow_step %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=rq0, step=fs )}}" style="font-size:0.75em;" class="flex-shrink-0 lh-1 p-1 btn btn-outline-vhppurple rounded-pill border border-vhppurple d-inline-flex align-items-center text-nowrap">{{fs}}</a>{% endfor %}
+                            </div>
+                            <button type="button" class="scroll-caret d-none position-absolute end-0 top-50 translate-middle-y btn btn-light btn-sm rounded-circle shadow-sm p-1 lh-1 d-flex align-items-center justify-content-center" aria-label="Scroll for more">
+                                <i class="bi bi-caret-right-fill text-secondary" style="font-size:0.7em;"></i>
+                            </button>
+                        </div>
                     </div>
                     <div class="card-body">
                         <h5 class="card-title" style="word-break: break-word;">
                             {{ study.title or 'Untitled Study' }}
                         </h5>
                         <div class="card-text">
-                            <span class="text-secondary">Released: {{ study.release_date or study.rdate or 'N/A' }}</span><br>
+                            <span class="small text-muted fst-italic">Released: {{ study.release_date or study.rdate or 'N/A' }}</span>
                         </div>
                     </div>
                     <div class="card-footer btn-group bg-white border-0 py-3" role="group">
@@ -159,7 +166,7 @@
                             {{ dataset.title or 'Untitled Dataset' }}
                         </h5>
                         <div class="card-text">
-                            <span class="text-secondary">Released: {{ dataset.metadata.publication_date or study.created or 'N/A' }}</span>
+                            <span class="small text-muted fst-italic">Released: {{ dataset.metadata.publication_date or study.created or 'N/A' }}</span>
                         </div>
                     </div>
                     <div class="card-footer btn-group bg-white border-0 py-3" role="group">
@@ -231,6 +238,31 @@
             },
             showFilterPanel: {% if filter_case_study or filter_flow_step or filter_regulatory_question %}true{% else %}false{% endif %}
         });
+    });
+</script>
+<script>
+    // Show the scroll-hint caret only when a pill strip actually overflows
+    // (and hide it once scrolled to the end).
+    document.addEventListener('DOMContentLoaded', () => {
+        const strips = document.querySelectorAll('.pill-scroll');
+        const sync = (strip) => {
+            const caret = strip.parentElement.querySelector('.scroll-caret');
+            if (!caret) return;
+            const overflowing = strip.scrollWidth > strip.clientWidth + 1;
+            const atEnd = strip.scrollLeft + strip.clientWidth >= strip.scrollWidth - 1;
+            caret.classList.toggle('d-none', !overflowing || atEnd);
+        };
+        strips.forEach((strip) => {
+            const caret = strip.parentElement.querySelector('.scroll-caret');
+            if (caret) {
+                caret.addEventListener('click', () => {
+                    strip.scrollBy({ left: strip.clientWidth * 0.8, behavior: 'smooth' });
+                });
+            }
+            strip.addEventListener('scroll', () => sync(strip), { passive: true });
+            sync(strip);
+        });
+        window.addEventListener('resize', () => strips.forEach(sync));
     });
 </script>
 

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -962,9 +962,9 @@
     <div class="card-footer">
      
         {% set cs0 = data.metadata.case_study[0] if data.metadata.case_study else '' %}
-        {% set rq0 = data.metadata.regulatory_question[0] if data.metadata.regulatory_question else '' %}
+        {% set rq0 = reg_q_labels.get(data.metadata.regulatory_question[0], data.metadata.regulatory_question[0]) if data.metadata.regulatory_question else '' %}
         {% for cs in data.metadata.case_study %}<a role="button" href="{{url_for('casestudy', case=cs|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">{{cs|capitalize }}</a> {% endfor %}
-        {% for rq in data.metadata.regulatory_question %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=rq )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">{{rq}}</a> {% endfor %}
+        {% for rq in data.metadata.regulatory_question %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=reg_q_labels.get(rq, rq) )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">{{ reg_q_labels.get(rq, rq) }}</a> {% endfor %}
         {% for fs in data.metadata.flow_step %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=rq0, step=fs )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppurple rounded-pill border border-vhppurple d-inline-flex align-items-center text-wrap">{{fs}}</a> {% endfor %}
 
     </div>

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -647,47 +647,87 @@
             <div class="mt-3">
               {% for ex in exposure_subs %}
 
-                {% set ns_ex = namespace(exp_type=None, duration=None, duration_unit=None, extra=[]) %}
+                {% set ns_ex = namespace(exp_type=None, duration=None, duration_unit=None, bioassays=[], extra=[]) %}
                 {% for a in ex.attributes or [] %}
                   {% if a.name == 'Exposure type' %}{% set ns_ex.exp_type = a.value %}
                   {% elif a.name == 'Exposure duration' %}{% set ns_ex.duration = a.value %}
                     {% set du = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}
                     {% set ns_ex.duration_unit = du[0] if du else None %}
+                  {% elif a.name == 'Bioassay' %}{% set _ = ns_ex.bioassays.append(a.value) %}
                   {% else %}{% if a.value %}{% set _ = ns_ex.extra.append(a) %}{% endif %}
                   {% endif %}
                 {% endfor %}
 
-                <div class="card mb-3">
-                  <div class="card-body p-3">
-                    <div class="d-flex align-items-start gap-3">
+                {# nested per-regimen subsections (shared-parent + regimen-deltas form) #}
+                {% set regimens = [] %}
+                {% for grp in ex.subsections or [] %}
+                  {% for s in grp %}
+                    {% if s.type and s.type|lower == 'exposure regimen' %}{% set _ = regimens.append(s) %}{% endif %}
+                  {% endfor %}
+                {% endfor %}
 
-                      <div class="flex-shrink-0 pt-1">
-                        <i class="bi bi-clock-history text-vhpblue fs-4"></i>
+                {% if regimens %}
+                  {# auto-detect regimen attributes common to ALL regimens (vs varying) #}
+                  {% set names = [] %}
+                  {% for r in regimens %}{% for a in r.attributes or [] %}{% if a.name not in ['Bioassay','Regimen'] and a.name not in names %}{% set _ = names.append(a.name) %}{% endif %}{% endfor %}{% endfor %}
+                  {% set common = [] %}
+                  {% for nm in names %}
+                    {% set cn = namespace(vals=[], count=0) %}
+                    {% for r in regimens %}{% for a in r.attributes or [] %}{% if a.name == nm %}{% set cn.count = cn.count + 1 %}{% if a.value not in cn.vals %}{% set _ = cn.vals.append(a.value) %}{% endif %}{% endif %}{% endfor %}{% endfor %}
+                    {% if cn.count == regimens|length and cn.vals|length == 1 %}{% set _ = common.append(nm) %}{% endif %}
+                  {% endfor %}
+
+                  {% if ns_ex.extra or common or ns_ex.bioassays %}
+                    <div class="small text-muted mb-2">
+                      {% set sp = namespace(n=false) %}
+                      {% for a in ns_ex.extra %}{% if sp.n %} &middot; {% endif %}{{ a.name }}: {{ a.value }}{% set eu = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}{% if eu %} {{ eu[0] }}{% endif %}{% set sp.n = true %}{% endfor %}
+                      {% for nm in common %}{% if sp.n %} &middot; {% endif %}{% set fa = regimens[0].attributes | selectattr('name','equalto',nm) | list | first %}{{ nm }}: {{ fa.value }}{% set u = (fa.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if fa.valqual else [] %}{% if u %} {{ u[0] }}{% endif %}{% set sp.n = true %}{% endfor %}
+                      {% if ns_ex.bioassays %}{% if sp.n %} &middot; {% endif %}Bioassays: {% for bn in ns_ex.bioassays %}{% if not loop.first %}, {% endif %}{% set m = namespace(url=None) %}{% for b in ns_bio.bioassays %}{% if b.value and b.value|lower|trim == bn|lower|trim %}{% set m.url = b.url or b.bao_url %}{% endif %}{% endfor %}{% if m.url %}<a href="{{ m.url }}" target="_blank" rel="noopener">{{ bn }}</a>{% else %}{{ bn }}{% endif %}{% endfor %}{% endif %}
+                    </div>
+                  {% endif %}
+
+                  {% for r in regimens %}
+                    {% set rb = namespace(name=None, bioassays=[], uniq=[]) %}
+                    {% for a in r.attributes or [] %}
+                      {% if a.name == 'Regimen' %}{% set rb.name = a.value %}
+                      {% elif a.name == 'Bioassay' %}{% set _ = rb.bioassays.append(a.value) %}
+                      {% elif a.name not in common and a.value %}{% set _ = rb.uniq.append(a) %}{% endif %}
+                    {% endfor %}
+                    <div class="card mb-2">
+                      <div class="card-body py-2 px-3">
+                        <div class="fw-semibold small">{% if rb.uniq %}{% for a in rb.uniq %}{% if not loop.first %} &middot; {% endif %}{{ a.name }}: {{ a.value }}{% set u = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}{% if u %} {{ u[0] }}{% endif %}{% endfor %}{% else %}{{ rb.name or 'Regimen' }}{% endif %}</div>
+                        {% if rb.bioassays %}
+                          <div class="small mt-1"><span class="text-muted">Bioassays:</span> {% for bn in rb.bioassays %}{% if not loop.first %}, {% endif %}{% set m = namespace(url=None) %}{% for b in ns_bio.bioassays %}{% if b.value and b.value|lower|trim == bn|lower|trim %}{% set m.url = b.url or b.bao_url %}{% endif %}{% endfor %}{% if m.url %}<a href="{{ m.url }}" target="_blank" rel="noopener">{{ bn }}</a>{% else %}{{ bn }}{% endif %}{% endfor %}</div>
+                        {% endif %}
                       </div>
+                    </div>
+                  {% endfor %}
 
-                      <div class="w-100">
-                        <div class="fw-semibold">{{ ns_ex.exp_type | capitalize if ns_ex.exp_type else '—' }} exposure</div>
-
-                        {% if ns_ex.duration %}
-                          <div class="small mt-1">
-                            <span class="text-muted">Duration:</span>
-                            {{ ns_ex.duration }}{% if ns_ex.duration_unit %} {{ ns_ex.duration_unit }}{% endif %}
-                          </div>
-                        {% endif %}
-
-                        {% if ns_ex.extra %}
-                          <div class="small text-muted mt-2">
-                            {% for a in ns_ex.extra %}
-                              {% if not loop.first %} &middot; {% endif %}
-                              {{ a.name }}: {{ a.value }}{% set eu = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}{% if eu %} {{ eu[0] }}{% endif %}
-                            {% endfor %}
-                          </div>
-                        {% endif %}
-
+                {% else %}
+                  <div class="card mb-3">
+                    <div class="card-body p-3">
+                      <div class="d-flex align-items-start gap-3">
+                        <div class="flex-shrink-0 pt-1">
+                          <i class="bi bi-clock-history text-vhpblue fs-4"></i>
+                        </div>
+                        <div class="w-100">
+                          <div class="fw-semibold">{{ ns_ex.exp_type | capitalize if ns_ex.exp_type else '—' }} exposure</div>
+                          {% if ns_ex.duration %}
+                            <div class="small mt-1"><span class="text-muted">Duration:</span> {{ ns_ex.duration }}{% if ns_ex.duration_unit %} {{ ns_ex.duration_unit }}{% endif %}</div>
+                          {% endif %}
+                          {% if ns_ex.bioassays %}
+                            <div class="small mt-1"><span class="text-muted">Bioassays:</span> {% for bn in ns_ex.bioassays %}{% if not loop.first %}, {% endif %}{% set m = namespace(url=None) %}{% for b in ns_bio.bioassays %}{% if b.value and b.value|lower|trim == bn|lower|trim %}{% set m.url = b.url or b.bao_url %}{% endif %}{% endfor %}{% if m.url %}<a href="{{ m.url }}" target="_blank" rel="noopener">{{ bn }}</a>{% else %}{{ bn }}{% endif %}{% endfor %}</div>
+                          {% endif %}
+                          {% if ns_ex.extra %}
+                            <div class="small text-muted mt-1">
+                              {% for a in ns_ex.extra %}{% if not loop.first %} &middot; {% endif %}{{ a.name }}: {{ a.value }}{% set eu = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}{% if eu %} {{ eu[0] }}{% endif %}{% endfor %}
+                            </div>
+                          {% endif %}
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
+                {% endif %}
 
               {% endfor %}
             </div>

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -434,7 +434,7 @@
             <div class="mt-3">
               {% for bm in bio_models %}
 
-                {% set ns_bm = namespace(cell_line=None, rrid=None, rrid_url=None, supplier=None, cell_type=None, cell_type_url=None, description=None, extra=[]) %}
+                {% set ns_bm = namespace(cell_line=None, rrid=None, rrid_url=None, supplier=None, cell_type=None, cell_type_url=None, organ=None, organ_url=None, tissue=None, tissue_url=None, description=None, extra=[]) %}
                 {% for a in bm.attributes or [] %}
                   {% if a.name == 'Cell line' %}
                     {% set ns_bm.cell_line = a.value %}
@@ -451,6 +451,18 @@
                       {% elif q.name == 'TermId' %}{% set ns_bm.cell_type_url = 'https://purl.obolibrary.org/obo/' ~ q.value | replace(':','_') %}{% endif %}
                     {% endfor %}
                     {% set ns_bm.cell_type = a.value %}
+                  {% elif a.name == 'Organ' %}
+                    {% for q in a.valqual or [] %}
+                      {% if q.name == 'URL' %}{% set ns_bm.organ_url = q.value %}
+                      {% elif q.name == 'TermId' %}{% set ns_bm.organ_url = 'https://purl.obolibrary.org/obo/' ~ q.value | replace(':','_') %}{% endif %}
+                    {% endfor %}
+                    {% set ns_bm.organ = a.value %}
+                  {% elif a.name == 'Tissue' %}
+                    {% for q in a.valqual or [] %}
+                      {% if q.name == 'URL' %}{% set ns_bm.tissue_url = q.value %}
+                      {% elif q.name == 'TermId' %}{% set ns_bm.tissue_url = 'https://purl.obolibrary.org/obo/' ~ q.value | replace(':','_') %}{% endif %}
+                    {% endfor %}
+                    {% set ns_bm.tissue = a.value %}
                   {% elif a.name and a.name|lower == 'description' %}
                     {% set ns_bm.description = a.value %}
                   {% else %}
@@ -503,21 +515,26 @@
                             {% endfor %}
                           {% endif %}
 
-                          {% if ns_bio.organ %}
+                          {# Organ/Tissue: prefer per-cell-line (e.g. multi-model studies), fall back to section-level #}
+                          {% set _organ = ns_bm.organ or ns_bio.organ %}
+                          {% set _organ_url = ns_bm.organ_url or ns_bio.organ_url %}
+                          {% if _organ %}
                             &middot;
-                            {% if ns_bio.organ_url %}
-                              <a href="{{ ns_bio.organ_url }}" target="_blank" rel="noopener" class="text-muted"><i class="bi bi-link-45deg text-vhpblue"></i> {{ ns_bio.organ }}</a>
+                            {% if _organ_url %}
+                              <a href="{{ _organ_url }}" target="_blank" rel="noopener" class="text-muted"><i class="bi bi-link-45deg text-vhpblue"></i> {{ _organ }}</a>
                             {% else %}
-                              {{ ns_bio.organ }}
+                              {{ _organ }}
                             {% endif %}
                           {% endif %}
 
-                          {% if ns_bio.tissue %}
+                          {% set _tissue = ns_bm.tissue or ns_bio.tissue %}
+                          {% set _tissue_url = ns_bm.tissue_url or ns_bio.tissue_url %}
+                          {% if _tissue %}
                             &middot;
-                            {% if ns_bio.tissue_url %}
-                              <a href="{{ ns_bio.tissue_url }}" target="_blank" rel="noopener" class="text-muted"><i class="bi bi-link-45deg text-vhpblue"></i> {{ ns_bio.tissue }}</a>
+                            {% if _tissue_url %}
+                              <a href="{{ _tissue_url }}" target="_blank" rel="noopener" class="text-muted"><i class="bi bi-link-45deg text-vhpblue"></i> {{ _tissue }}</a>
                             {% else %}
-                              {{ ns_bio.tissue }}
+                              {{ _tissue }}
                             {% endif %}
                           {% endif %}
 
@@ -946,7 +963,32 @@
             <p class="text-muted mt-3">No endpoint readout information available.</p>
           {% endif %}
 
-          {% if ns_bio.aop_name or ns_bio.aop_events %}
+          {# AOP Linkage: key events aggregated from the per-bioassay endpoint readouts (single source of truth),
+             each annotated with the bioassay(s) that measure it. #}
+          {% set ns_aop = namespace(events=[], names=[]) %}
+          {% for ep in endpoint_subs %}
+            {% set epx = namespace(ba=None, evs=[]) %}
+            {% for a in ep.attributes or [] %}
+              {% if a.name == 'Bioassay' %}{% set epx.ba = a.value %}
+              {% elif a.name == 'AOP event' %}
+                {% set ev = namespace(url=None) %}
+                {% for q in a.valqual or [] %}{% if q.name == 'URL' %}{% set ev.url = q.value %}{% endif %}{% endfor %}
+                {% set _ = epx.evs.append({'value': a.value, 'url': ev.url}) %}
+              {% endif %}
+            {% endfor %}
+            {% for ev in epx.evs %}
+              {% set key = ev.value|lower|trim %}
+              {% if key in ns_aop.names %}
+                {% set idx = ns_aop.names.index(key) %}
+                {% if epx.ba and epx.ba not in ns_aop.events[idx].bioassays %}{% set _ = ns_aop.events[idx].bioassays.append(epx.ba) %}{% endif %}
+              {% else %}
+                {% set _ = ns_aop.names.append(key) %}
+                {% set _ = ns_aop.events.append({'value': ev.value, 'url': ev.url, 'bioassays': ([epx.ba] if epx.ba else [])}) %}
+              {% endif %}
+            {% endfor %}
+          {% endfor %}
+
+          {% if ns_bio.aop_name or ns_aop.events %}
           <div class="card overflow-hidden mt-3">
             <div class="card-header py-2"><h5 class="m-0">AOP Linkage</h5></div>
             <div class="card-body p-0">
@@ -963,7 +1005,7 @@
                   </span>
                 </li>
                 {% endif %}
-                {% for ev in ns_bio.aop_events %}
+                {% for ev in ns_aop.events %}
                 <li class="list-group-item d-flex align-items-start gap-2">
                   <i class="bi bi-arrow-right-circle text-vhpblue"></i>
                   <span class="small">

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -961,9 +961,11 @@
      {% if record.type=="study"%}
     <div class="card-footer">
      
-        {% if data.metadata.case_study%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">Case Study: {{data.metadata.case_study|capitalize }}</a>{%endif%}
-        {% if data.metadata.regulatory_question%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower, question=data.metadata.regulatory_question )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">Regulatory Question: {{data.metadata.regulatory_question}}</a>{%endif%}
-        {% if data.metadata.flow_step%}<a role="button" href="{{url_for('casestudy', case=data.metadata.case_study|lower, question=data.metadata.regulatory_question, step=data.metadata.flow_step )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppurple rounded-pill border border-vhppurple d-inline-flex align-items-center text-wrap">Flow Step: {{data.metadata.flow_step}}</a>{%endif%}
+        {% set cs0 = data.metadata.case_study[0] if data.metadata.case_study else '' %}
+        {% set rq0 = data.metadata.regulatory_question[0] if data.metadata.regulatory_question else '' %}
+        {% for cs in data.metadata.case_study %}<a role="button" href="{{url_for('casestudy', case=cs|lower)}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">{{cs|capitalize }}</a> {% endfor %}
+        {% for rq in data.metadata.regulatory_question %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=rq )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppink-distinct rounded-pill border border-vhppink-distinct d-inline-flex align-items-center text-wrap">{{rq}}</a> {% endfor %}
+        {% for fs in data.metadata.flow_step %}<a role="button" href="{{url_for('casestudy', case=cs0|lower, question=rq0, step=fs )}}" style="font-size:0.75em;" class="lh-1 p-1 btn btn-outline-vhppurple rounded-pill border border-vhppurple d-inline-flex align-items-center text-wrap">{{fs}}</a> {% endfor %}
 
     </div>
       {% endif %}

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -161,8 +161,7 @@
          --------------------------- #}
       {% set subs_bio = [] %}
       {% set bio_models = [] %}
-      {% set ns_bio = namespace(organisms=[], organ=None, organ_url=None, tissue=None, tissue_url=None, bioassays=[], aop_events=[]) %}
-
+      {% set ns_bio = namespace(organisms=[], organ=None, organ_url=None, tissue=None, tissue_url=None, bioassays=[], aop_name=None, aop_url=None) %}
       {% if record.type == "study" %}
         {% set sec_attrs = data.metadata.raw_data.section.attributes
           if data.metadata and data.metadata.raw_data and data.metadata.raw_data.section else [] %}
@@ -200,12 +199,13 @@
             {% endfor %}
             {% set _ = ns_bio.bioassays.append({'value': a.value, 'url': ba.url, 'bao_url': ba.bao_url, 'ontology': ba.ontology}) %}
 
-          {% elif a.name == 'AOP event' %}
-            {% set aop_url = namespace(url=None) %}
+          {% elif a.name == 'AOP' %}
+            {% set aop_q = namespace(url=None) %}
             {% for q in a.valqual or [] %}
-              {% if q.name == 'URL' %}{% set aop_url.url = q.value %}{% endif %}
+              {% if q.name == 'URL' %}{% set aop_q.url = q.value %}{% endif %}
             {% endfor %}
-            {% set _ = ns_bio.aop_events.append({'value': a.value, 'url': aop_url.url}) %}
+            {% set ns_bio.aop_name = a.value %}
+            {% set ns_bio.aop_url = aop_q.url %}
           {% endif %}
         {% endfor %}
 
@@ -696,10 +696,11 @@
             {% endif %}
           {% endfor %}
 
-          {% set ns_used = namespace(names=[]) %}
-
           {% if endpoint_subs %}
-            <div class="mt-3">
+          <div class="card mt-3">
+            <div class="card-header py-2"><h5 class="m-0">Bioassays</h5></div>
+            <div class="card-body p-0">
+              <ul class="list-group list-group-flush">
               {% for ep in endpoint_subs %}
 
                 {% set ns_ep = namespace(bioassay_name=None, aop_event=None, aop_event_url=None, instrument=None, manufacturer=None, measured_entity=None, readout=None, readout_unit=None, time_point=None, time_point_unit=None, replicates=None, extra=[]) %}
@@ -738,10 +739,8 @@
                   {% set ns_ba.bao_url = ns_bio.bioassays[0].bao_url %}
                   {% set ns_ba.ontology = ns_bio.bioassays[0].ontology %}
                 {% endif %}
-                {% if ns_ba.value %}{% set _ = ns_used.names.append(ns_ba.value|lower|trim) %}{% endif %}
 
-                <div class="card mb-3">
-                  <div class="card-body p-3">
+                <li class="list-group-item">
                     <div class="d-flex align-items-start gap-3">
 
                       <div class="flex-shrink-0 pt-1">
@@ -758,7 +757,7 @@
                               {{ ns_ba.value }}
                             {% endif %}
                             {% if ns_ba.ontology %}
-                              <span class="badge bg-vhpblue rounded-pill ms-1" style="font-size:0.7em;">{{ ns_ba.ontology }}</span>
+                              <span class="badge bg-vhpblue rounded-pill ms-1">{{ ns_ba.ontology }}</span>
                             {% endif %}
                           {% else %}
                             {{ ns_ep.instrument or '—' }}
@@ -820,37 +819,10 @@
 
                       </div>
                     </div>
-                  </div>
-                </div>
+                </li>
 
               {% endfor %}
-            </div>
-          {% endif %}
-
-          {# Bioassays declared at study level but not linked to any readout block #}
-          {% set ns_left = namespace(items=[]) %}
-          {% for b in ns_bio.bioassays %}
-            {% if b.value and (b.value|lower|trim) not in ns_used.names %}
-              {% set _ = ns_left.items.append(b) %}
-            {% endif %}
-          {% endfor %}
-          {% if ns_left.items %}
-          <div class="card mt-3">
-            <div class="card-header py-2"><h5 class="m-0">Bioassay{{ 's' if ns_left.items|length > 1 else '' }}</h5></div>
-            <div class="card-body py-2 px-3">
-              {% for b in ns_left.items %}
-                <div{% if not loop.first %} class="mt-1"{% endif %}>
-                  {% set b_link = b.url or b.bao_url %}
-                  {% if b_link %}
-                    <a href="{{ b_link }}" target="_blank" rel="noopener">{{ b.value }}</a>
-                  {% else %}
-                    {{ b.value }}
-                  {% endif %}
-                  {% if b.ontology %}
-                    <span class="badge bg-vhpblue rounded-pill ms-1" style="font-size:0.7em;">{{ b.ontology }}</span>
-                  {% endif %}
-                </div>
-              {% endfor %}
+              </ul>
             </div>
           </div>
           {% endif %}
@@ -859,24 +831,20 @@
             <p class="text-muted mt-3">No endpoint readout information available.</p>
           {% endif %}
 
-          {% if ns_bio.aop_events %}
+          {% if ns_bio.aop_name %}
           <div class="card mt-3">
             <div class="card-header py-2"><h5 class="m-0">AOP Linkage</h5></div>
-            <div class="card-body p-0">
-              <ul class="list-group list-group-flush">
-                {% for ev in ns_bio.aop_events %}
-                  <li class="list-group-item d-flex align-items-start gap-2">
-                    <i class="bi bi-arrow-right-circle text-vhpblue"></i>
-                    <span class="small">
-                      {% if ev.url %}
-                        <a href="{{ ev.url }}" target="_blank" rel="noopener">{{ ev.value }}</a>
-                      {% else %}
-                        {{ ev.value }}
-                      {% endif %}
-                    </span>
-                  </li>
-                {% endfor %}
-              </ul>
+            <div class="card-body py-2 px-3">
+              <div class="d-flex align-items-start gap-2">
+                <i class="bi bi-diagram-3 text-vhpblue"></i>
+                <span class="small">
+                  {% if ns_bio.aop_url %}
+                    <a href="{{ ns_bio.aop_url }}" target="_blank" rel="noopener">{{ ns_bio.aop_name }}</a>
+                  {% else %}
+                    {{ ns_bio.aop_name }}
+                  {% endif %}
+                </span>
+              </div>
             </div>
           </div>
           {% endif %}

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -831,7 +831,7 @@
               <ul class="list-group list-group-flush">
               {% for ep in endpoint_subs %}
 
-                {% set ns_ep = namespace(bioassay_name=None, aop_events=[], instrument=None, manufacturer=None, measured_entity=None, readout=None, readout_unit=None, time_point=None, time_point_unit=None, replicates=None, description=None, extra=[]) %}
+                {% set ns_ep = namespace(bioassay_name=None, aop_events=[], instrument=None, manufacturer=None, measured_entity=None, readout=None, readout_unit=None, time_point=None, time_point_unit=None, replicates=None, tech_replicates=None, pos_controls=[], description=None, extra=[]) %}
                 {% for a in ep.attributes or [] %}
                   {% if a.name == 'Bioassay' %}{% set ns_ep.bioassay_name = a.value %}
                   {% elif a.name == 'AOP event' %}
@@ -848,6 +848,19 @@
                     {% set tu = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}
                     {% set ns_ep.time_point_unit = tu[0] if tu else None %}
                   {% elif a.name == 'Replicates' %}{% set ns_ep.replicates = a.value %}
+                  {% elif a.name == 'Technical replicates' %}{% set ns_ep.tech_replicates = a.value %}
+                  {% elif a.name == 'Positive control' %}
+                    {% set pc = namespace(name=a.value, url=None, conc=None, conc_unit=None, dur=None, dur_unit=None) %}
+                    {% for q in a.valqual or [] %}
+                      {% if q.name == 'URL' %}{% set pc.url = q.value %}
+                      {% elif q.name == 'CID' and not pc.url %}{% set pc.url = 'https://pubchem.ncbi.nlm.nih.gov/compound/' ~ q.value %}
+                      {% elif q.name|lower == 'concentration' %}{% set pc.conc = q.value %}
+                        {% set cu = (q.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if q.valqual else [] %}{% set pc.conc_unit = cu[0] if cu else None %}
+                      {% elif q.name == 'Exposure duration' %}{% set pc.dur = q.value %}
+                        {% set du = (q.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if q.valqual else [] %}{% set pc.dur_unit = du[0] if du else None %}
+                      {% endif %}
+                    {% endfor %}
+                    {% set _ = ns_ep.pos_controls.append(pc) %}
                   {% elif a.name and a.name|lower == 'description' %}{% set ns_ep.description = a.value %}
                   {% else %}{% if a.value %}{% set _ = ns_ep.extra.append(a) %}{% endif %}
                   {% endif %}
@@ -901,10 +914,12 @@
                         </div>
 
                         {% if ns_ep.aop_events %}
-                          <div class="small mt-1">
-                            <span class="text-muted">AOP event{{ 's' if ns_ep.aop_events|length > 1 else '' }}:</span>
-                            {% for ev in ns_ep.aop_events %}{% if not loop.first %} &middot; {% endif %}{% if ev.url %}<a href="{{ ev.url }}" target="_blank" rel="noopener">{{ ev.value }}</a>{% else %}{{ ev.value }}{% endif %}{% endfor %}
+                          {% for ev in ns_ep.aop_events %}
+                          <div class="small mt-1 d-flex align-items-start gap-2">
+                            <i class="bi bi-arrow-right-circle text-vhpblue"></i>
+                            <span>{% if ev.url %}<a href="{{ ev.url }}" target="_blank" rel="noopener">{{ ev.value }}</a>{% else %}{{ ev.value }}{% endif %}</span>
                           </div>
+                          {% endfor %}
                         {% endif %}
 
                         {% if ns_ba.value and ns_ep.instrument %}
@@ -942,7 +957,20 @@
                           {% if ns_ep.replicates %}
                             {% if sep.needed %} &middot; {% endif %}
                             Replicates: {{ ns_ep.replicates }}
+                            {% set sep.needed = true %}
                           {% endif %}
+
+                          {% if ns_ep.tech_replicates %}
+                            {% if sep.needed %} &middot; {% endif %}
+                            Technical replicates: {{ ns_ep.tech_replicates }}
+                            {% set sep.needed = true %}
+                          {% endif %}
+
+                          {% for pc in ns_ep.pos_controls %}
+                            {% if sep.needed %} &middot; {% endif %}
+                            Positive control: {% if pc.url %}<a href="{{ pc.url }}" target="_blank" rel="noopener">{{ pc.name }}</a>{% else %}{{ pc.name }}{% endif %}{% if pc.conc %} ({{ pc.conc }}{% if pc.conc_unit %} {{ pc.conc_unit }}{% endif %}{% if pc.dur %}, {{ pc.dur }}{% if pc.dur_unit %} {{ pc.dur_unit }}{% endif %}{% endif %}){% endif %}
+                            {% set sep.needed = true %}
+                          {% endfor %}
 
                           {% for a in ns_ep.extra %}
                             <br>{{ a.name }}: {{ a.value }}{% set eu = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}{% if eu %} {{ eu[0] }}{% endif %}

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -135,21 +135,12 @@
 
         <li class="nav-item" role="presentation">
           <a class="nav-link text-vhpblue "
-             id="tab-pubs-link"
-             data-bs-toggle="tab"
-             href="#tab-publications"
-             role="tab"
-             aria-controls="tab-publications"
-             aria-selected="false">Publications</a>
-        </li>
-        <li class="nav-item" role="presentation">
-          <a class="nav-link text-vhpblue "
              id="tab-how-to-cite-link"
              data-bs-toggle="tab"
              href="#tab-how-to-cite"
              role="tab"
              aria-controls="tab-how-to-cite"
-             aria-selected="false">How to Cite</a>
+             aria-selected="false">Citation</a>
         </li>
       </ul>
     </div>
@@ -161,7 +152,7 @@
          --------------------------- #}
       {% set subs_bio = [] %}
       {% set bio_models = [] %}
-      {% set ns_bio = namespace(organisms=[], organ=None, organ_url=None, tissue=None, tissue_url=None, bioassays=[], aop_name=None, aop_url=None, aop_events=[]) %}
+      {% set ns_bio = namespace(organisms=[], organ=None, organ_url=None, tissue=None, tissue_url=None, cell_type=None, cell_type_url=None, bioassays=[], aop_name=None, aop_url=None, aop_events=[]) %}
       {% if record.type == "study" %}
         {% set sec_attrs = data.metadata.raw_data.section.attributes
           if data.metadata and data.metadata.raw_data and data.metadata.raw_data.section else [] %}
@@ -230,6 +221,7 @@
            GENERAL TAB (norm_metadata)
            --------------------------- #}
         <div class="tab-pane fade show active" id="tab-general" role="tabpanel" aria-labelledby="tab-general-link">
+          <div class="mt-3">
           <div class="row g-3">
             <div class="col-md-8">
               <div class="card mb-3">
@@ -272,6 +264,42 @@
                 </div>
               </div>
              
+              <div class="card mb-3">
+                <div class="card-header py-2"><h5 class="m-0">Publications</h5></div>
+                <div class="card-body p-0">
+                  {% if record.publications and record.publications|length > 0 %}
+                    <ul class="list-group list-group-flush">
+                      {% for pub in record.publications %}
+                        <li class="list-group-item publication-entry d-flex align-items-start gap-2" data-doi="{{ pub.doi or '' }}">
+                          <i class="bi bi-book text-vhpblue pt-1"></i>
+                          <div class="w-100 small">
+                            <div class="pub-citation">
+                              <p class="mb-0 text-muted">Loading citation…</p>
+                            </div>
+                            {% if pub.doi %}
+                              <div class="text-muted mt-1 text-break">
+                                <i class="bi bi-link-45deg text-vhpblue"></i>
+                                <a href="https://doi.org/{{ pub.doi }}" target="_blank" rel="noopener">https://doi.org/{{ pub.doi }}</a>
+                              </div>
+                            {% elif pub.pmid %}
+                              <div class="text-muted mt-1">
+                                PMID: <a href="https://pubmed.ncbi.nlm.nih.gov/{{ pub.pmid }}/" target="_blank" rel="noopener">{{ pub.pmid }}</a>
+                              </div>
+                            {% elif pub.url %}
+                              <div class="text-muted mt-1 text-break">
+                                <a href="{{ pub.url }}" target="_blank" rel="noopener">{{ pub.url }}</a>
+                              </div>
+                            {% endif %}
+                          </div>
+                        </li>
+                      {% endfor %}
+                    </ul>
+                  {% else %}
+                    <p class="text-muted mb-0 p-3">No linked publications available.</p>
+                  {% endif %}
+                </div>
+              </div>
+
               <div class="card overflow-hidden">
                 <div class="card-header py-2">
                 <h5 class="m-0">Files</h5>
@@ -393,6 +421,7 @@
 
             </div>
           </div>
+          </div>
         </div>
 
         {# ---------------------------
@@ -405,7 +434,7 @@
             <div class="mt-3">
               {% for bm in bio_models %}
 
-                {% set ns_bm = namespace(cell_line=None, rrid=None, rrid_url=None, supplier=None, extra=[]) %}
+                {% set ns_bm = namespace(cell_line=None, rrid=None, rrid_url=None, supplier=None, cell_type=None, cell_type_url=None, description=None, extra=[]) %}
                 {% for a in bm.attributes or [] %}
                   {% if a.name == 'Cell line' %}
                     {% set ns_bm.cell_line = a.value %}
@@ -416,6 +445,14 @@
                     {% endfor %}
                   {% elif a.name == 'Supplier' %}
                     {% set ns_bm.supplier = a.value %}
+                  {% elif a.name == 'Cell type' %}
+                    {% for q in a.valqual or [] %}
+                      {% if q.name == 'URL' %}{% set ns_bm.cell_type_url = q.value %}
+                      {% elif q.name == 'TermId' %}{% set ns_bm.cell_type_url = 'https://purl.obolibrary.org/obo/' ~ q.value | replace(':','_') %}{% endif %}
+                    {% endfor %}
+                    {% set ns_bm.cell_type = a.value %}
+                  {% elif a.name and a.name|lower == 'description' %}
+                    {% set ns_bm.description = a.value %}
                   {% else %}
                     {% if a.value %}{% set _ = ns_bm.extra.append(a) %}{% endif %}
                   {% endif %}
@@ -446,20 +483,19 @@
                             {% else %}
                               {{ ns_bm.rrid }}
                             {% endif %}
+                          {% if ns_bm.supplier %}
+                            {% if ns_bm.rrid %} &middot; {% endif %}<span>Supplier: {{ ns_bm.supplier }}</span>
+                          {% endif %}
                           </div>
                         {% endif %}
 
                         {# Muted secondary details #}
                         <div class="small text-muted mt-2">
-                          {% if ns_bm.supplier %}
-                            <span>Supplier: {{ ns_bm.supplier }}</span>
-                          {% endif %}
 
                           {% if ns_bio.organisms %}
-                            {% if ns_bm.supplier %} &middot; {% endif %}
                             {% for org in ns_bio.organisms %}
                               {% if org.url %}
-                                <a href="{{ org.url }}" target="_blank" rel="noopener" class="text-muted">{{ org.value }}</a>
+                                <a href="{{ org.url }}" target="_blank" rel="noopener" class="text-muted"><i class="bi bi-link-45deg text-vhpblue"></i> {{ org.value }}</a>
                               {% else %}
                                 {{ org.value }}
                               {% endif %}
@@ -470,7 +506,7 @@
                           {% if ns_bio.organ %}
                             &middot;
                             {% if ns_bio.organ_url %}
-                              <a href="{{ ns_bio.organ_url }}" target="_blank" rel="noopener" class="text-muted">{{ ns_bio.organ }}</a>
+                              <a href="{{ ns_bio.organ_url }}" target="_blank" rel="noopener" class="text-muted"><i class="bi bi-link-45deg text-vhpblue"></i> {{ ns_bio.organ }}</a>
                             {% else %}
                               {{ ns_bio.organ }}
                             {% endif %}
@@ -479,9 +515,18 @@
                           {% if ns_bio.tissue %}
                             &middot;
                             {% if ns_bio.tissue_url %}
-                              <a href="{{ ns_bio.tissue_url }}" target="_blank" rel="noopener" class="text-muted">{{ ns_bio.tissue }}</a>
+                              <a href="{{ ns_bio.tissue_url }}" target="_blank" rel="noopener" class="text-muted"><i class="bi bi-link-45deg text-vhpblue"></i> {{ ns_bio.tissue }}</a>
                             {% else %}
                               {{ ns_bio.tissue }}
+                            {% endif %}
+                          {% endif %}
+
+                          {% if ns_bm.cell_type %}
+                            &middot;
+                            {% if ns_bm.cell_type_url %}
+                              <a href="{{ ns_bm.cell_type_url }}" target="_blank" rel="noopener" class="text-muted"><i class="bi bi-link-45deg text-vhpblue"></i> {{ ns_bm.cell_type }}</a>
+                            {% else %}
+                              {{ ns_bm.cell_type }}
                             {% endif %}
                           {% endif %}
 
@@ -489,6 +534,13 @@
                             <br>{{ a.name }}: {{ a.value }}
                           {% endfor %}
                         </div>
+
+                        {% if ns_bm.description %}
+                          <div class="d-flex gap-2 mt-2">
+                            <div class="vr"></div>
+                            <p class="small text-secondary mb-0">{{ ns_bm.description }}</p>
+                          </div>
+                        {% endif %}
 
                       </div>
                     </div>
@@ -681,15 +733,6 @@
                     {% if cn.count == regimens|length and cn.vals|length == 1 %}{% set _ = common.append(nm) %}{% endif %}
                   {% endfor %}
 
-                  {% if ns_ex.extra or common or ns_ex.bioassays %}
-                    <div class="small text-muted mb-2">
-                      {% set sp = namespace(n=false) %}
-                      {% for a in ns_ex.extra %}{% if sp.n %} &middot; {% endif %}{{ a.name }}: {{ a.value }}{% set eu = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}{% if eu %} {{ eu[0] }}{% endif %}{% set sp.n = true %}{% endfor %}
-                      {% for nm in common %}{% if sp.n %} &middot; {% endif %}{% set fa = regimens[0].attributes | selectattr('name','equalto',nm) | list | first %}{{ nm }}: {{ fa.value }}{% set u = (fa.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if fa.valqual else [] %}{% if u %} {{ u[0] }}{% endif %}{% set sp.n = true %}{% endfor %}
-                      {% if ns_ex.bioassays %}{% if sp.n %} &middot; {% endif %}Bioassays: {% for bn in ns_ex.bioassays %}{% if not loop.first %}, {% endif %}{% set m = namespace(url=None) %}{% for b in ns_bio.bioassays %}{% if b.value and b.value|lower|trim == bn|lower|trim %}{% set m.url = b.url or b.bao_url %}{% endif %}{% endfor %}{% if m.url %}<a href="{{ m.url }}" target="_blank" rel="noopener">{{ bn }}</a>{% else %}{{ bn }}{% endif %}{% endfor %}{% endif %}
-                    </div>
-                  {% endif %}
-
                   {% for r in regimens %}
                     {% set rb = namespace(name=None, bioassays=[], uniq=[]) %}
                     {% for a in r.attributes or [] %}
@@ -699,10 +742,26 @@
                     {% endfor %}
                     <div class="card mb-2">
                       <div class="card-body py-2 px-3">
-                        <div class="fw-semibold small">{% if rb.uniq %}{% for a in rb.uniq %}{% if not loop.first %} &middot; {% endif %}{{ a.name }}: {{ a.value }}{% set u = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}{% if u %} {{ u[0] }}{% endif %}{% endfor %}{% else %}{{ rb.name or 'Regimen' }}{% endif %}</div>
-                        {% if rb.bioassays %}
-                          <div class="small mt-1"><span class="text-muted">Bioassays:</span> {% for bn in rb.bioassays %}{% if not loop.first %}, {% endif %}{% set m = namespace(url=None) %}{% for b in ns_bio.bioassays %}{% if b.value and b.value|lower|trim == bn|lower|trim %}{% set m.url = b.url or b.bao_url %}{% endif %}{% endfor %}{% if m.url %}<a href="{{ m.url }}" target="_blank" rel="noopener">{{ bn }}</a>{% else %}{{ bn }}{% endif %}{% endfor %}</div>
+                        <div class="d-flex align-items-start gap-3">
+                          <div class="flex-shrink-0 pt-1">
+                            <i class="bi bi-clock-history text-vhpblue fs-4"></i>
+                          </div>
+                          <div class="w-100">
+                        <div class="small">{% if rb.uniq %}{% for a in rb.uniq %}{% if not loop.first %} &middot; {% endif %}{{ a.name }}: {{ a.value }}{% set u = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}{% if u %} {{ u[0] }}{% endif %}{% endfor %}{% else %}{{ rb.name or 'Regimen' }}{% endif %}</div>
+                        {# shared items — valid for all regimens, repeated in each card for clarity #}
+                        {% if ns_ex.extra or common or ns_ex.bioassays %}
+                          <div class="small text-muted mt-1">
+                            {% set sp = namespace(n=false) %}
+                            {% for a in ns_ex.extra %}{% if sp.n %} &middot; {% endif %}{{ a.name }}: {{ a.value }}{% set eu = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}{% if eu %} {{ eu[0] }}{% endif %}{% set sp.n = true %}{% endfor %}
+                            {% for nm in common %}{% if sp.n %} &middot; {% endif %}{% set fa = regimens[0].attributes | selectattr('name','equalto',nm) | list | first %}{{ nm }}: {{ fa.value }}{% set u = (fa.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if fa.valqual else [] %}{% if u %} {{ u[0] }}{% endif %}{% set sp.n = true %}{% endfor %}
+                            {% if ns_ex.bioassays %}{% if sp.n %} &middot; {% endif %}Bioassays: {% for bn in ns_ex.bioassays %}{% if not loop.first %}, {% endif %}{% set m = namespace(url=None) %}{% for b in ns_bio.bioassays %}{% if b.value and b.value|lower|trim == bn|lower|trim %}{% set m.url = b.url or b.bao_url %}{% endif %}{% endfor %}{% if m.url %}<a href="{{ m.url }}" target="_blank" rel="noopener" class="fw-semibold text-nowrap"><i class="bi bi-link-45deg text-vhpblue"></i> {{ bn }}</a>{% else %}{{ bn }}{% endif %}{% endfor %}{% endif %}
+                          </div>
                         {% endif %}
+                        {% if rb.bioassays %}
+                          <div class="small mt-1"><span class="text-muted">Bioassays:</span> {% for bn in rb.bioassays %}{% if not loop.first %}, {% endif %}{% set m = namespace(url=None) %}{% for b in ns_bio.bioassays %}{% if b.value and b.value|lower|trim == bn|lower|trim %}{% set m.url = b.url or b.bao_url %}{% endif %}{% endfor %}{% if m.url %}<a href="{{ m.url }}" target="_blank" rel="noopener" class="fw-semibold text-nowrap"><i class="bi bi-link-45deg text-vhpblue"></i> {{ bn }}</a>{% else %}{{ bn }}{% endif %}{% endfor %}</div>
+                        {% endif %}
+                          </div>
+                        </div>
                       </div>
                     </div>
                   {% endfor %}
@@ -720,7 +779,7 @@
                             <div class="small mt-1"><span class="text-muted">Duration:</span> {{ ns_ex.duration }}{% if ns_ex.duration_unit %} {{ ns_ex.duration_unit }}{% endif %}</div>
                           {% endif %}
                           {% if ns_ex.bioassays %}
-                            <div class="small mt-1"><span class="text-muted">Bioassays:</span> {% for bn in ns_ex.bioassays %}{% if not loop.first %}, {% endif %}{% set m = namespace(url=None) %}{% for b in ns_bio.bioassays %}{% if b.value and b.value|lower|trim == bn|lower|trim %}{% set m.url = b.url or b.bao_url %}{% endif %}{% endfor %}{% if m.url %}<a href="{{ m.url }}" target="_blank" rel="noopener">{{ bn }}</a>{% else %}{{ bn }}{% endif %}{% endfor %}</div>
+                            <div class="small mt-1"><span class="text-muted">Bioassays:</span> {% for bn in ns_ex.bioassays %}{% if not loop.first %}, {% endif %}{% set m = namespace(url=None) %}{% for b in ns_bio.bioassays %}{% if b.value and b.value|lower|trim == bn|lower|trim %}{% set m.url = b.url or b.bao_url %}{% endif %}{% endfor %}{% if m.url %}<a href="{{ m.url }}" target="_blank" rel="noopener" class="fw-semibold text-nowrap"><i class="bi bi-link-45deg text-vhpblue"></i> {{ bn }}</a>{% else %}{{ bn }}{% endif %}{% endfor %}</div>
                           {% endif %}
                           {% if ns_ex.extra %}
                             <div class="small text-muted mt-1">
@@ -749,7 +808,7 @@
           {% endfor %}
 
           {% if endpoint_subs %}
-          <div class="card mt-3">
+          <div class="card overflow-hidden mt-3">
             <div class="card-header py-2"><h5 class="m-0">Bioassays</h5></div>
             <div class="card-body p-0">
               <ul class="list-group list-group-flush">
@@ -813,7 +872,11 @@
                               {{ ns_ba.value }}
                             {% endif %}
                             {% if ns_ba.ontology %}
-                              <span class="badge bg-vhpblue rounded-pill ms-1">{{ ns_ba.ontology }}</span>
+                              {% if ns_ba.bao_url %}
+                                <a href="{{ ns_ba.bao_url }}" target="_blank" rel="noopener" class="badge rounded-pill ms-1 text-decoration-none btn btn-vhpblue">{{ ns_ba.ontology }}</a>
+                              {% else %}
+                                <span class="badge bg-vhpblue rounded-pill ms-1">{{ ns_ba.ontology }}</span>
+                              {% endif %}
                             {% endif %}
                           {% else %}
                             {{ ns_ep.instrument or '—' }}
@@ -884,7 +947,7 @@
           {% endif %}
 
           {% if ns_bio.aop_name or ns_bio.aop_events %}
-          <div class="card mt-3">
+          <div class="card overflow-hidden mt-3">
             <div class="card-header py-2"><h5 class="m-0">AOP Linkage</h5></div>
             <div class="card-body p-0">
               <ul class="list-group list-group-flush">
@@ -925,48 +988,6 @@
         {# ---------------------------
            PUBLICATIONS TAB (DOI-based)
            --------------------------- #} 
-
-        <div class="tab-pane fade" id="tab-publications" role="tabpanel" aria-labelledby="tab-pubs-link">
-
-          {% if record.publications and record.publications|length > 0 %}
-            <div class="mt-3">
-              {% for pub in record.publications %}
-                <div class="card publication-entry mb-3" data-doi="{{ pub.doi or '' }}">
-                  <div class="card-body p-3">
-                    <div class="d-flex align-items-start gap-3">
-                      <div class="flex-shrink-0 pt-1">
-                        <i class="bi bi-book text-vhpblue fs-4"></i>
-                      </div>
-                      <div class="w-100">
-                        <div class="pub-citation small">
-                          <p class="mb-0 text-muted">Loading citation…</p>
-                        </div>
-                        {% if pub.doi %}
-                          <div class="small text-muted mt-1">
-                            <i class="bi bi-link-45deg text-vhpblue"></i>
-                            <a href="https://doi.org/{{ pub.doi }}" target="_blank" rel="noopener">
-                              https://doi.org/{{ pub.doi }}
-                            </a>
-                          </div>
-                        {% elif pub.pmid %}
-                          <div class="small text-muted mt-1">
-                            PMID: <a href="https://pubmed.ncbi.nlm.nih.gov/{{ pub.pmid }}/" target="_blank" rel="noopener">{{ pub.pmid }}</a>
-                          </div>
-                        {% elif pub.url %}
-                          <div class="small text-muted mt-1">
-                            <a href="{{ pub.url }}" target="_blank" rel="noopener">{{ pub.url }}</a>
-                          </div>
-                        {% endif %}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              {% endfor %}
-            </div>
-          {% else %}
-            <p class="text-muted mt-3 mb-0">No linked publications available.</p>
-          {% endif %}
-        </div>
 
       <div class="tab-pane fade" id="tab-how-to-cite" role="tabpanel" aria-labelledby="tab-how-to-cite-link">
         {% if record.doi %}

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -623,13 +623,13 @@
                           {% endif %}
 
                           <div class="w-100">
-                            {# Chemical name (optionally link to CompoundCloud) #}
+                            {# Chemical name -> VHP4Safety platform compound page (derived from the CompoundCloud/Wiki ID) #}
                             <div class="fw-semibold">
-                              {% if ns.cc_url %}
-                                <a href="{{ ns.cc_url }}" target="_blank" rel="noopener" class="text-decoration-none">
+                              {% if ns.cc_id and '[DRAFT]' not in ns.cc_id %}
+                                <a href="https://platform.vhp4safety.nl/compound/{{ ns.cc_id|trim|urlencode }}"
+                                   rel="noopener" class="text-decoration-none">
                                   {{ ns.name or '—' }}
                                 </a>
-                                <i class="bi bi-box-arrow-up-right ms-1 small text-muted"></i>
                               {% else %}
                                 {{ ns.name or '—' }}
                               {% endif %}

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -651,7 +651,8 @@
                 {% for a in ex.attributes or [] %}
                   {% if a.name == 'Exposure type' %}{% set ns_ex.exp_type = a.value %}
                   {% elif a.name == 'Exposure duration' %}{% set ns_ex.duration = a.value %}
-                  {% elif a.name == 'Exposure duration_unit' %}{% set ns_ex.duration_unit = a.value %}
+                    {% set du = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}
+                    {% set ns_ex.duration_unit = du[0] if du else None %}
                   {% else %}{% if a.value %}{% set _ = ns_ex.extra.append(a) %}{% endif %}
                   {% endif %}
                 {% endfor %}
@@ -678,7 +679,7 @@
                           <div class="small text-muted mt-2">
                             {% for a in ns_ex.extra %}
                               {% if not loop.first %} &middot; {% endif %}
-                              {{ a.name }}: {{ a.value }}
+                              {{ a.name }}: {{ a.value }}{% set eu = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}{% if eu %} {{ eu[0] }}{% endif %}
                             {% endfor %}
                           </div>
                         {% endif %}
@@ -721,9 +722,11 @@
                   {% elif a.name == 'Instrument manufacturer' %}{% set ns_ep.manufacturer = a.value %}
                   {% elif a.name == 'Measured entity' %}{% set ns_ep.measured_entity = a.value %}
                   {% elif a.name == 'Endpoint readout' %}{% set ns_ep.readout = a.value %}
-                  {% elif a.name == 'Endpoint readout_unit' %}{% set ns_ep.readout_unit = a.value %}
+                    {% set ru = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}
+                    {% set ns_ep.readout_unit = ru[0] if ru else None %}
                   {% elif a.name == 'Time point' %}{% set ns_ep.time_point = a.value %}
-                  {% elif a.name == 'Time point_unit' %}{% set ns_ep.time_point_unit = a.value %}
+                    {% set tu = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}
+                    {% set ns_ep.time_point_unit = tu[0] if tu else None %}
                   {% elif a.name == 'Replicates' %}{% set ns_ep.replicates = a.value %}
                   {% elif a.name and a.name|lower == 'description' %}{% set ns_ep.description = a.value %}
                   {% else %}{% if a.value %}{% set _ = ns_ep.extra.append(a) %}{% endif %}
@@ -818,7 +821,7 @@
                           {% endif %}
 
                           {% for a in ns_ep.extra %}
-                            <br>{{ a.name }}: {{ a.value }}
+                            <br>{{ a.name }}: {{ a.value }}{% set eu = (a.valqual | selectattr('name','equalto','Unit') | map(attribute='value') | list) if a.valqual else [] %}{% if eu %} {{ eu[0] }}{% endif %}
                           {% endfor %}
                         </div>
 

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -161,7 +161,7 @@
          --------------------------- #}
       {% set subs_bio = [] %}
       {% set bio_models = [] %}
-      {% set ns_bio = namespace(organisms=[], organ=None, organ_url=None, tissue=None, tissue_url=None, bioassay=None, bioassay_url=None, bioassay_ontology=None, aop_events=[]) %}
+      {% set ns_bio = namespace(organisms=[], organ=None, organ_url=None, tissue=None, tissue_url=None, bioassays=[], aop_events=[]) %}
 
       {% if record.type == "study" %}
         {% set sec_attrs = data.metadata.raw_data.section.attributes
@@ -192,11 +192,13 @@
             {% set ns_bio.tissue = a.value %}
 
           {% elif a.name == 'Bioassay' %}
+            {% set ba = namespace(url=None, bao_url=None, ontology=None) %}
             {% for q in a.valqual or [] %}
-              {% if q.name == 'TermId' %}{% set ns_bio.bioassay_url = 'https://www.bioassayontology.org/bao#' ~ q.value %}{% endif %}
-              {% if q.name == 'Ontology' %}{% set ns_bio.bioassay_ontology = q.value %}{% endif %}
+              {% if q.name == 'URL' %}{% set ba.url = q.value %}{% endif %}
+              {% if q.name == 'TermId' %}{% set ba.bao_url = 'https://www.bioassayontology.org/bao#' ~ q.value %}{% endif %}
+              {% if q.name == 'Ontology' %}{% set ba.ontology = q.value %}{% endif %}
             {% endfor %}
-            {% set ns_bio.bioassay = a.value %}
+            {% set _ = ns_bio.bioassays.append({'value': a.value, 'url': ba.url, 'bao_url': ba.bao_url, 'ontology': ba.ontology}) %}
 
           {% elif a.name == 'AOP event' %}
             {% set aop_url = namespace(url=None) %}
@@ -694,29 +696,19 @@
             {% endif %}
           {% endfor %}
 
-          {% if ns_bio.bioassay %}
-          <div class="card mt-3">
-            <div class="card-header py-2"><h5 class="m-0">Bioassay</h5></div>
-            <div class="card-body py-2 px-3">
-              {% if ns_bio.bioassay_url %}
-                <a href="{{ ns_bio.bioassay_url }}" target="_blank" rel="noopener">{{ ns_bio.bioassay }}</a>
-              {% else %}
-                {{ ns_bio.bioassay }}
-              {% endif %}
-              {% if ns_bio.bioassay_ontology %}
-                <span class="badge bg-vhpblue rounded-pill ms-1" style="font-size:0.7em;">{{ ns_bio.bioassay_ontology }}</span>
-              {% endif %}
-            </div>
-          </div>
-          {% endif %}
+          {% set ns_used = namespace(names=[]) %}
 
           {% if endpoint_subs %}
             <div class="mt-3">
               {% for ep in endpoint_subs %}
 
-                {% set ns_ep = namespace(instrument=None, manufacturer=None, measured_entity=None, readout=None, readout_unit=None, time_point=None, time_point_unit=None, replicates=None, extra=[]) %}
+                {% set ns_ep = namespace(bioassay_name=None, aop_event=None, aop_event_url=None, instrument=None, manufacturer=None, measured_entity=None, readout=None, readout_unit=None, time_point=None, time_point_unit=None, replicates=None, extra=[]) %}
                 {% for a in ep.attributes or [] %}
-                  {% if a.name == 'Detection instrument' %}{% set ns_ep.instrument = a.value %}
+                  {% if a.name == 'Bioassay' %}{% set ns_ep.bioassay_name = a.value %}
+                  {% elif a.name == 'AOP event' %}
+                    {% set ns_ep.aop_event = a.value %}
+                    {% for q in a.valqual or [] %}{% if q.name == 'URL' %}{% set ns_ep.aop_event_url = q.value %}{% endif %}{% endfor %}
+                  {% elif a.name == 'Detection instrument' %}{% set ns_ep.instrument = a.value %}
                   {% elif a.name == 'Instrument manufacturer' %}{% set ns_ep.manufacturer = a.value %}
                   {% elif a.name == 'Measured entity' %}{% set ns_ep.measured_entity = a.value %}
                   {% elif a.name == 'Endpoint readout' %}{% set ns_ep.readout = a.value %}
@@ -728,6 +720,26 @@
                   {% endif %}
                 {% endfor %}
 
+                {# Resolve which bioassay this readout block describes #}
+                {% set ns_ba = namespace(value=None, url=None, bao_url=None, ontology=None) %}
+                {% if ns_ep.bioassay_name %}
+                  {% for b in ns_bio.bioassays %}
+                    {% if b.value and b.value|lower|trim == ns_ep.bioassay_name|lower|trim %}
+                      {% set ns_ba.value = b.value %}
+                      {% set ns_ba.url = b.url %}
+                      {% set ns_ba.bao_url = b.bao_url %}
+                      {% set ns_ba.ontology = b.ontology %}
+                    {% endif %}
+                  {% endfor %}
+                  {% if not ns_ba.value %}{% set ns_ba.value = ns_ep.bioassay_name %}{% endif %}
+                {% elif ns_bio.bioassays|length == 1 %}
+                  {% set ns_ba.value = ns_bio.bioassays[0].value %}
+                  {% set ns_ba.url = ns_bio.bioassays[0].url %}
+                  {% set ns_ba.bao_url = ns_bio.bioassays[0].bao_url %}
+                  {% set ns_ba.ontology = ns_bio.bioassays[0].ontology %}
+                {% endif %}
+                {% if ns_ba.value %}{% set _ = ns_used.names.append(ns_ba.value|lower|trim) %}{% endif %}
+
                 <div class="card mb-3">
                   <div class="card-body p-3">
                     <div class="d-flex align-items-start gap-3">
@@ -737,7 +749,38 @@
                       </div>
 
                       <div class="w-100">
-                        <div class="fw-semibold">{{ ns_ep.instrument or '—' }}</div>
+                        <div class="fw-semibold">
+                          {% if ns_ba.value %}
+                            {% set ba_link = ns_ba.url or ns_ba.bao_url %}
+                            {% if ba_link %}
+                              <a href="{{ ba_link }}" target="_blank" rel="noopener">{{ ns_ba.value }}</a>
+                            {% else %}
+                              {{ ns_ba.value }}
+                            {% endif %}
+                            {% if ns_ba.ontology %}
+                              <span class="badge bg-vhpblue rounded-pill ms-1" style="font-size:0.7em;">{{ ns_ba.ontology }}</span>
+                            {% endif %}
+                          {% else %}
+                            {{ ns_ep.instrument or '—' }}
+                          {% endif %}
+                        </div>
+
+                        {% if ns_ep.aop_event %}
+                          <div class="small mt-1">
+                            <span class="text-muted">AOP event:</span>
+                            {% if ns_ep.aop_event_url %}
+                              <a href="{{ ns_ep.aop_event_url }}" target="_blank" rel="noopener">{{ ns_ep.aop_event }}</a>
+                            {% else %}
+                              {{ ns_ep.aop_event }}
+                            {% endif %}
+                          </div>
+                        {% endif %}
+
+                        {% if ns_ba.value and ns_ep.instrument %}
+                          <div class="small mt-1">
+                            <span class="text-muted">Instrument:</span> {{ ns_ep.instrument }}
+                          </div>
+                        {% endif %}
 
                         {% if ns_ep.manufacturer %}
                           <div class="small mt-1">
@@ -782,6 +825,38 @@
 
               {% endfor %}
             </div>
+          {% endif %}
+
+          {# Bioassays declared at study level but not linked to any readout block #}
+          {% set ns_left = namespace(items=[]) %}
+          {% for b in ns_bio.bioassays %}
+            {% if b.value and (b.value|lower|trim) not in ns_used.names %}
+              {% set _ = ns_left.items.append(b) %}
+            {% endif %}
+          {% endfor %}
+          {% if ns_left.items %}
+          <div class="card mt-3">
+            <div class="card-header py-2"><h5 class="m-0">Bioassay{{ 's' if ns_left.items|length > 1 else '' }}</h5></div>
+            <div class="card-body py-2 px-3">
+              {% for b in ns_left.items %}
+                <div{% if not loop.first %} class="mt-1"{% endif %}>
+                  {% set b_link = b.url or b.bao_url %}
+                  {% if b_link %}
+                    <a href="{{ b_link }}" target="_blank" rel="noopener">{{ b.value }}</a>
+                  {% else %}
+                    {{ b.value }}
+                  {% endif %}
+                  {% if b.ontology %}
+                    <span class="badge bg-vhpblue rounded-pill ms-1" style="font-size:0.7em;">{{ b.ontology }}</span>
+                  {% endif %}
+                </div>
+              {% endfor %}
+            </div>
+          </div>
+          {% endif %}
+
+          {% if not endpoint_subs and not ns_bio.bioassays %}
+            <p class="text-muted mt-3">No endpoint readout information available.</p>
           {% endif %}
 
           {% if ns_bio.aop_events %}

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -161,7 +161,7 @@
          --------------------------- #}
       {% set subs_bio = [] %}
       {% set bio_models = [] %}
-      {% set ns_bio = namespace(organisms=[], organ=None, organ_url=None, tissue=None, tissue_url=None, bioassays=[], aop_name=None, aop_url=None) %}
+      {% set ns_bio = namespace(organisms=[], organ=None, organ_url=None, tissue=None, tissue_url=None, bioassays=[], aop_name=None, aop_url=None, aop_events=[]) %}
       {% if record.type == "study" %}
         {% set sec_attrs = data.metadata.raw_data.section.attributes
           if data.metadata and data.metadata.raw_data and data.metadata.raw_data.section else [] %}
@@ -206,6 +206,13 @@
             {% endfor %}
             {% set ns_bio.aop_name = a.value %}
             {% set ns_bio.aop_url = aop_q.url %}
+
+          {% elif a.name == 'AOP event' %}
+            {% set ev_q = namespace(url=None) %}
+            {% for q in a.valqual or [] %}
+              {% if q.name == 'URL' %}{% set ev_q.url = q.value %}{% endif %}
+            {% endfor %}
+            {% set _ = ns_bio.aop_events.append({'value': a.value, 'url': ev_q.url}) %}
           {% endif %}
         {% endfor %}
 
@@ -831,20 +838,36 @@
             <p class="text-muted mt-3">No endpoint readout information available.</p>
           {% endif %}
 
-          {% if ns_bio.aop_name %}
+          {% if ns_bio.aop_name or ns_bio.aop_events %}
           <div class="card mt-3">
             <div class="card-header py-2"><h5 class="m-0">AOP Linkage</h5></div>
-            <div class="card-body py-2 px-3">
-              <div class="d-flex align-items-start gap-2">
-                <i class="bi bi-diagram-3 text-vhpblue"></i>
-                <span class="small">
-                  {% if ns_bio.aop_url %}
-                    <a href="{{ ns_bio.aop_url }}" target="_blank" rel="noopener">{{ ns_bio.aop_name }}</a>
-                  {% else %}
-                    {{ ns_bio.aop_name }}
-                  {% endif %}
-                </span>
-              </div>
+            <div class="card-body p-0">
+              <ul class="list-group list-group-flush">
+                {% if ns_bio.aop_name %}
+                <li class="list-group-item d-flex align-items-start gap-2">
+                  <i class="bi bi-diagram-3 text-vhpblue"></i>
+                  <span class="small">
+                    {% if ns_bio.aop_url %}
+                      <a href="{{ ns_bio.aop_url }}" target="_blank" rel="noopener">{{ ns_bio.aop_name }}</a>
+                    {% else %}
+                      {{ ns_bio.aop_name }}
+                    {% endif %}
+                  </span>
+                </li>
+                {% endif %}
+                {% for ev in ns_bio.aop_events %}
+                <li class="list-group-item d-flex align-items-start gap-2">
+                  <i class="bi bi-arrow-right-circle text-vhpblue"></i>
+                  <span class="small">
+                    {% if ev.url %}
+                      <a href="{{ ev.url }}" target="_blank" rel="noopener">{{ ev.value }}</a>
+                    {% else %}
+                      {{ ev.value }}
+                    {% endif %}
+                  </span>
+                </li>
+                {% endfor %}
+              </ul>
             </div>
           </div>
           {% endif %}

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -710,12 +710,13 @@
               <ul class="list-group list-group-flush">
               {% for ep in endpoint_subs %}
 
-                {% set ns_ep = namespace(bioassay_name=None, aop_event=None, aop_event_url=None, instrument=None, manufacturer=None, measured_entity=None, readout=None, readout_unit=None, time_point=None, time_point_unit=None, replicates=None, extra=[]) %}
+                {% set ns_ep = namespace(bioassay_name=None, aop_events=[], instrument=None, manufacturer=None, measured_entity=None, readout=None, readout_unit=None, time_point=None, time_point_unit=None, replicates=None, description=None, extra=[]) %}
                 {% for a in ep.attributes or [] %}
                   {% if a.name == 'Bioassay' %}{% set ns_ep.bioassay_name = a.value %}
                   {% elif a.name == 'AOP event' %}
-                    {% set ns_ep.aop_event = a.value %}
-                    {% for q in a.valqual or [] %}{% if q.name == 'URL' %}{% set ns_ep.aop_event_url = q.value %}{% endif %}{% endfor %}
+                    {% set ev = namespace(url=None) %}
+                    {% for q in a.valqual or [] %}{% if q.name == 'URL' %}{% set ev.url = q.value %}{% endif %}{% endfor %}
+                    {% set _ = ns_ep.aop_events.append({'value': a.value, 'url': ev.url}) %}
                   {% elif a.name == 'Detection instrument' %}{% set ns_ep.instrument = a.value %}
                   {% elif a.name == 'Instrument manufacturer' %}{% set ns_ep.manufacturer = a.value %}
                   {% elif a.name == 'Measured entity' %}{% set ns_ep.measured_entity = a.value %}
@@ -724,6 +725,7 @@
                   {% elif a.name == 'Time point' %}{% set ns_ep.time_point = a.value %}
                   {% elif a.name == 'Time point_unit' %}{% set ns_ep.time_point_unit = a.value %}
                   {% elif a.name == 'Replicates' %}{% set ns_ep.replicates = a.value %}
+                  {% elif a.name and a.name|lower == 'description' %}{% set ns_ep.description = a.value %}
                   {% else %}{% if a.value %}{% set _ = ns_ep.extra.append(a) %}{% endif %}
                   {% endif %}
                 {% endfor %}
@@ -771,14 +773,10 @@
                           {% endif %}
                         </div>
 
-                        {% if ns_ep.aop_event %}
+                        {% if ns_ep.aop_events %}
                           <div class="small mt-1">
-                            <span class="text-muted">AOP event:</span>
-                            {% if ns_ep.aop_event_url %}
-                              <a href="{{ ns_ep.aop_event_url }}" target="_blank" rel="noopener">{{ ns_ep.aop_event }}</a>
-                            {% else %}
-                              {{ ns_ep.aop_event }}
-                            {% endif %}
+                            <span class="text-muted">AOP event{{ 's' if ns_ep.aop_events|length > 1 else '' }}:</span>
+                            {% for ev in ns_ep.aop_events %}{% if not loop.first %} &middot; {% endif %}{% if ev.url %}<a href="{{ ev.url }}" target="_blank" rel="noopener">{{ ev.value }}</a>{% else %}{{ ev.value }}{% endif %}{% endfor %}
                           </div>
                         {% endif %}
 

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -516,116 +516,120 @@
 
           {% if chemicals|length > 0 %}
             <div class="mt-3">
+              <div class="row">
+                {% for chem in chemicals %}
 
-              {% for chem in chemicals %}
+                  
+                  {# ---- Extract chemical fields from subsection attributes ---- #}
+                  {% set ns = namespace(
+                    name=None,
+                    cas=None,
+                    cid=None,
+                    cc_id=None,
+                    cc_url=None
+                  ) %}
 
-                
-                {# ---- Extract chemical fields from subsection attributes ---- #}
-                {% set ns = namespace(
-                  name=None,
-                  cas=None,
-                  cid=None,
-                  cc_id=None,
-                  cc_url=None
-                ) %}
+                  {% for a in chem.attributes or [] %}
+                    {% if a.name == 'Chemical' %}
+                      {% set ns.name = a.value %}
+                    {% elif a.name == 'CAS' %}
+                      {% set ns.cas = a.value %}
+                    {% elif a.name in ['CID', 'PubChemCID', 'PubChem CID'] %}
+                      {% set ns.cid = a.value %}
+                    {% elif a.name == 'CompoundCloudID' %}
+                      {% set ns.cc_id = a.value %}
+                      {% for q in a.valqual or [] %}
+                        {% if q.name == 'URL' %}
+                          {% set ns.cc_url = q.value %}
+                        {% endif %}
+                      {% endfor %}
+                    {% endif %}
+                  {% endfor %}
 
-                {% for a in chem.attributes or [] %}
-                  {% if a.name == 'Chemical' %}
-                    {% set ns.name = a.value %}
-                  {% elif a.name == 'CAS' %}
-                    {% set ns.cas = a.value %}
-                  {% elif a.name in ['CID', 'PubChemCID', 'PubChem CID'] %}
-                    {% set ns.cid = a.value %}
-                  {% elif a.name == 'CompoundCloudID' %}
-                    {% set ns.cc_id = a.value %}
-                    {% for q in a.valqual or [] %}
-                      {% if q.name == 'URL' %}
-                        {% set ns.cc_url = q.value %}
-                      {% endif %}
-                    {% endfor %}
-                  {% endif %}
-                {% endfor %}
+                  {# ---- Render card in col-md-6 ---- #}
+                  <div class="col-md-6">
+                    <div class="card mb-3">
+                      <div class="card-body p-3">
 
-                {# ---- Render card ---- #}
-                <div class="card mb-3">
-                  <div class="card-body p-3">
-
-                    <div class="d-flex align-items-start gap-3">
-                      {# Optional: PubChem structure image (only if CID present) #}
-                      {% if ns.cid %}
-                        <div class="flex-shrink-0">
-                          <img
-                            src="https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/{{ ns.cid|urlencode }}/PNG"
-                            alt="Structure for CID {{ ns.cid }}"
-                            class="border rounded bg-white"
-                            style="width:120px; height:auto;"
-                            loading="lazy"
-                          >
-                        </div>
-                      {% else %}
-                        <div class="flex-shrink-0 pt-1">
-                          <i class="bi bi-droplet-fill text-vhpblue fs-4"></i>
-                        </div>
-                      {% endif %}
-
-                      <div class="w-100">
-                        {# Chemical name (optionally link to CompoundCloud) #}
-                        <div class="fw-semibold">
-                          {% if ns.cc_url %}
-                            <a href="{{ ns.cc_url }}" target="_blank" rel="noopener" class="text-decoration-none">
-                              {{ ns.name or '—' }}
-                            </a>
-                            <i class="bi bi-box-arrow-up-right ms-1 small text-muted"></i>
-                          {% else %}
-                            {{ ns.name or '—' }}
-                          {% endif %}
-                        </div>
-
-                        {# Identifiers row #}
-                        <div class="small mt-1">
-
-                          {# CAS -> Common Chemistry search #}
-                          {% if ns.cas %}
-                            <span class="text-muted">CAS:</span>
-                            <a href="https://commonchemistry.cas.org/results?q={{ ns.cas|urlencode }}"
-                              target="_blank" rel="noopener" class="text-decoration-none">
-                              <i class="bi bi-link-45deg text-vhpblue"></i> {{ ns.cas }}
-                            </a>
-                          {% endif %}
-
-                          {# PubChem CID link #}
+                        <div class="d-flex align-items-start gap-3">
+                          {# Optional: PubChem structure image (only if CID present) #}
                           {% if ns.cid %}
-                            {% if ns.cas %}<br>{% endif %}
-                            <span class="text-muted">PubChem:</span>
-                            <a href="https://pubchem.ncbi.nlm.nih.gov/compound/{{ ns.cid|urlencode }}"
-                              target="_blank" rel="noopener" class="text-decoration-none">
-                              <i class="bi bi-link-45deg text-vhpblue"></i> CID {{ ns.cid }}
-                            </a>
+                            <div class="flex-shrink-0">
+                              <img
+                                src="https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/{{ ns.cid|urlencode }}/PNG"
+                                alt="Structure for CID {{ ns.cid }}"
+                                class="border rounded bg-white"
+                                style="width:120px; height:auto;"
+                                loading="lazy"
+                                onerror="this.onerror=null; this.src='https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid={{ ns.cid }}&t=l';"
+                              >
+                            </div>
+                          {% else %}
+                            <div class="flex-shrink-0 pt-1">
+                              <i class="bi bi-droplet-fill text-vhpblue fs-4"></i>
+                            </div>
                           {% endif %}
 
-                          {# CompoundCloud ID link (if you want it explicitly as well) #}
-                          {% if ns.cc_id %}
-                            <br>
-                            <span class="text-muted">CompoundCloud:</span>
-                            {% if ns.cc_url %}
-                              <a href="{{ ns.cc_url }}" target="_blank" rel="noopener" class="text-decoration-none">
-                                <i class="bi bi-link-45deg text-vhpblue"></i> {{ ns.cc_id }}
-                              </a>
-                            {% else %}
-                              {{ ns.cc_id }}
-                            {% endif %}
-                          {% endif %}
+                          <div class="w-100">
+                            {# Chemical name (optionally link to CompoundCloud) #}
+                            <div class="fw-semibold">
+                              {% if ns.cc_url %}
+                                <a href="{{ ns.cc_url }}" target="_blank" rel="noopener" class="text-decoration-none">
+                                  {{ ns.name or '—' }}
+                                </a>
+                                <i class="bi bi-box-arrow-up-right ms-1 small text-muted"></i>
+                              {% else %}
+                                {{ ns.name or '—' }}
+                              {% endif %}
+                            </div>
 
+                            {# Identifiers row #}
+                            <div class="small mt-1">
+
+                              {# CAS -> Common Chemistry search #}
+                              {% if ns.cas %}
+                                <span class="text-muted">CAS:</span>
+                                <a href="https://commonchemistry.cas.org/results?q={{ ns.cas|urlencode }}"
+                                  target="_blank" rel="noopener" class="text-decoration-none">
+                                  <i class="bi bi-link-45deg text-vhpblue"></i> {{ ns.cas }}
+                                </a>
+                              {% endif %}
+
+                              {# PubChem CID link #}
+                              {% if ns.cid %}
+                                {% if ns.cas %}<br>{% endif %}
+                                <span class="text-muted">PubChem:</span>
+                                <a href="https://pubchem.ncbi.nlm.nih.gov/compound/{{ ns.cid|urlencode }}"
+                                  target="_blank" rel="noopener" class="text-decoration-none">
+                                  <i class="bi bi-link-45deg text-vhpblue"></i> CID {{ ns.cid }}
+                                </a>
+                              {% endif %}
+
+                              {# CompoundCloud ID link (if you want it explicitly as well) #}
+                              {% if ns.cc_id %}
+                                <br>
+                                <span class="text-muted">CompoundCloud:</span>
+                                {% if ns.cc_url %}
+                                  <a href="{{ ns.cc_url }}" target="_blank" rel="noopener" class="text-decoration-none">
+                                    <i class="bi bi-link-45deg text-vhpblue"></i> {{ ns.cc_id }}
+                                  </a>
+                                {% else %}
+                                  {{ ns.cc_id }}
+                                {% endif %}
+                              {% endif %}
+
+                            </div>
+
+                          </div>
                         </div>
 
                       </div>
                     </div>
-
                   </div>
-                </div>
 
 
-              {% endfor %}
+                {% endfor %}
+              </div>
             </div>
           {% else %}
             <p class="text-muted">No chemical information available.</p>

--- a/templates/data/data_details.html
+++ b/templates/data/data_details.html
@@ -751,7 +751,7 @@
                     <div class="d-flex align-items-start gap-3">
 
                       <div class="flex-shrink-0 pt-1">
-                        <i class="bi bi-pc-display-horizontal text-vhpblue fs-4"></i>
+                        <i class="bi bi-clipboard-data text-vhpblue fs-4"></i>
                       </div>
 
                       <div class="w-100">


### PR DESCRIPTION
Changes to data.html and data_details.html

- filters behave like the rest of the platform
- Support multiple case studies, rq's and flow steps. 
- One card per bioassay, aop linkange is now derived from those assays
- links chemicals and methods out to the platform's own pages

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr><tr>
<td>
<img width="1906" height="992" alt="Screenshot 2026-05-25 at 13 54 08" src="https://github.com/user-attachments/assets/49eae262-3d82-45d9-b7ac-9a82fd2b21d6" />
</td><td>
<img width="1903" height="991" alt="Screenshot 2026-05-25 at 13 54 49" src="https://github.com/user-attachments/assets/0583ac2f-741d-49f4-95e6-058c0c6ab7e9" />
</td>
</tr>
<tr>
<td>
<img width="1903" height="992" alt="Screenshot 2026-05-25 at 13 57 12" src="https://github.com/user-attachments/assets/2595169c-7be8-4b64-b2a6-987147e928dc" />

</td><td>
<img width="1904" height="992" alt="Screenshot 2026-05-25 at 13 57 32" src="https://github.com/user-attachments/assets/0dd1a071-d313-4503-be9d-0746ef674484" />

</td>
</tr>
<tr>
<td>
<img width="1902" height="991" alt="Screenshot 2026-05-25 at 13 58 43" src="https://github.com/user-attachments/assets/39ca65b0-fc65-47a9-b8e3-0168f3268d33" />

</td><td>
<img width="1903" height="945" alt="Screenshot 2026-05-25 at 13 58 31" src="https://github.com/user-attachments/assets/dcb4e02c-8a70-4aae-8d35-6ca54695bc31" />

</td>
</tr>
</table>