### PR TITLE
Added a PeerTube section in the UI

### DIFF
--- a/templates/tools/tool.html
+++ b/templates/tools/tool.html
@@ -167,6 +167,26 @@
           </div>
           {% endif %}
 
+          {% if tool_details.peertube %}
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="doc-heading-vhp-info">
+              <button class="accordion-button collapsed" type="button"
+                      data-bs-toggle="collapse" data-bs-target="#doc-collapse-vhp-info"
+                      aria-expanded="false" aria-controls="doc-collapse-vhp-info">
+                Introduction video
+              </button>
+            </h2>
+            <div id="doc-collapse-vhp-info" class="accordion-collapse collapse"
+                 aria-labelledby="doc-heading-vhp-info"
+                 data-bs-parent="#tool-documentation-accordion">
+              <div class="accordion-body">
+                <h3>Introduction video</h3>
+                <div style="position: relative; padding-top: 56.25%;"><iframe title="{{ tool_details.peertube.title }}" width="100%" height="100%" src="{{ tool_details.peertube.url }}" allow="fullscreen" sandbox="allow-same-origin allow-scripts allow-popups allow-forms" style="border: 0px; position: absolute; inset: 0px;"></iframe></div>
+              </div>
+            </div>
+          </div>
+          {% endif %}
+
           {% if tool_details.get('ELIXIR') and tool_details.ELIXIR.get('tess') %}
           <div class="accordion-item">
             <h2 class="accordion-header" id="doc-heading-taxila">


### PR DESCRIPTION
Added a PeerTube video section to the tool info page:

<img width="748" height="727" alt="image" src="https://github.com/user-attachments/assets/46bfc7b0-4a7d-46c6-b7a4-40302875ae88" />

Based on the `cloud` patch today: https://github.com/VHP4Safety/cloud/commit/e51ef8ee78c1684c1d5097dadaf5d6eb276fbc1d